### PR TITLE
[BACK-1927] Disallow "1" in prescription access code

### DIFF
--- a/reference/prescription/models/accesscode.v1.yaml
+++ b/reference/prescription/models/accesscode.v1.yaml
@@ -2,6 +2,6 @@ type: string
 title: Access Code
 minLength: 6
 maxLength: 6
-pattern: '^[A-HJ-NP-Z1-9]+$'
+pattern: '^[A-HJ-NP-Z2-9]+$'
 x-tags:
   - prescription


### PR DESCRIPTION
Documentation update companion to https://github.com/tidepool-org/platform/pull/550