### PR TITLE
[BACK-1341] Add new device logs endpoints to blob api

### DIFF
--- a/reference/blob.v1.yaml
+++ b/reference/blob.v1.yaml
@@ -49,6 +49,59 @@ tags:
       If the blob is created with content or has been updated to include content then its status is `available`.
 
 paths:
+  '/v1/users/{userId}/device-logs':
+    parameters:
+      - $ref: ./common/parameters/tidepooluserid.yaml
+    post:
+      operationId: UploadDeviceLogs
+      summary: Upload new device logs as binary blobs
+      description: 'Upload s a new device logs binary blob in the user''s account. The `Content-Type` and the `Digest` headers must represent the media type and MD5 hash of the binary blob content, respectively.'
+      parameters:
+        - $ref: ./common/parameters/contenttype.v1.yaml
+        - $ref: ./common/parameters/digestmd5.v1.yaml
+        - schema:
+            type: string
+            format: date-time
+            example: '2017-02-06T02:37:46Z'
+          in: header
+          name: X-Logs-Start-At
+          description: Starting time of device logs inside the uploaded binary blob
+          required: true
+        - schema:
+            type: string
+            format: date-time
+            example: '2017-02-06T02:37:46Z'
+          in: header
+          name: X-Logs-End-At
+          description: End time of device logs inside the uploaded binary blob
+          required: true
+      requestBody:
+        description: Binary blob
+        required: true
+        content:
+          '*/*':
+            schema:
+              $ref: ./blob/models/content.v1.yaml
+            examples:
+              example-1:
+                value: string
+      responses:
+        '201':
+          $ref: '#/components/responses/DeviceLogsMetadata'
+      tags:
+        - Blobs
+    get:
+      operationId: ListDeviceLogs
+      summary: List Device Logs
+      description: List previously uploaded device logs binary blobs in the user's account. The list must be filtered with startAt and endAt parameters
+      parameters:
+        - $ref: ./blob/parameters/start-at.v1.yaml
+        - $ref: ./blob/parameters/end-at.v1.yaml
+      responses:
+        '200':
+          $ref: '#/components/responses/DeviceLogsMetadataList'
+      tags:
+        - Blobs
   '/v1/users/{userId}/blobs':
     parameters:
       - $ref: './common/parameters/tidepooluserid.yaml'
@@ -218,7 +271,18 @@ components:
           operationId: GetBlobContent
           parameters:
             blobId: '$response.body#/id'
-
+    DeviceLogsMetadata:
+      description: Device logs metadata
+      content:
+        application/json:
+          schema:
+            $ref: ./blob/models/device-logs-metadata.v1.yaml
+    DeviceLogsMetadataList:
+      description: List of binary blob metadata
+      content:
+        application/json:
+          schema:
+            $ref: ./blob/models/device-logs-metadatalist.v1.yaml
     BlobContent:
       description: Binary blob content
       headers:

--- a/reference/blob.v1.yaml
+++ b/reference/blob.v1.yaml
@@ -55,7 +55,7 @@ paths:
     post:
       operationId: UploadDeviceLogs
       summary: Upload new device logs as binary blobs
-      description: 'Upload s a new device logs binary blob in the user''s account. The `Content-Type` and the `Digest` headers must represent the media type and MD5 hash of the binary blob content, respectively.'
+      description: Uploads a new device logs binary blob to the user's account. The `Content-Type` and the `Digest` headers must represent the media type and MD5 hash of the binary blob content, respectively.
       parameters:
         - $ref: ./common/parameters/contenttype.v1.yaml
         - $ref: ./common/parameters/digestmd5.v1.yaml
@@ -64,7 +64,7 @@ paths:
             format: date-time
             example: '2017-02-06T02:37:46Z'
           in: header
-          name: X-Logs-Start-At
+          name: X-Logs-Start-At-Time
           description: Starting time of device logs inside the uploaded binary blob
           required: true
         - schema:
@@ -72,7 +72,7 @@ paths:
             format: date-time
             example: '2017-02-06T02:37:46Z'
           in: header
-          name: X-Logs-End-At
+          name: X-Logs-End-At-Time
           description: End time of device logs inside the uploaded binary blob
           required: true
       requestBody:
@@ -278,7 +278,7 @@ components:
           schema:
             $ref: ./blob/models/device-logs-metadata.v1.yaml
     DeviceLogsMetadataList:
-      description: List of binary blob metadata
+      description: List of device logs metadata
       content:
         application/json:
           schema:

--- a/reference/blob/models/device-logs-metadata.v1.yaml
+++ b/reference/blob/models/device-logs-metadata.v1.yaml
@@ -14,9 +14,9 @@ properties:
     $ref: './size.v1.yaml'
   createdTime:
     $ref: '../../common/models/datetime.v1.yaml'
-  startAt:
+  startAtTime:
     $ref: '../../common/models/datetime.v1.yaml'
-  endAt:
+  endAtTime:
     $ref: '../../common/models/datetime.v1.yaml'
 required:
   - id

--- a/reference/blob/models/device-logs-metadata.v1.yaml
+++ b/reference/blob/models/device-logs-metadata.v1.yaml
@@ -1,0 +1,29 @@
+title: Device logs blob metadata
+type: object
+readOnly: true
+properties:
+  id:
+    $ref: './id.v1.yaml'
+  userId:
+    $ref: '../../common/models/tidepooluserid.yaml'
+  digestMD5:
+    $ref: '../../common/models/digestmd5.v1.yaml'
+  mediaType:
+    $ref: '../../common/models/mediatype.v1.yaml'
+  size:
+    $ref: './size.v1.yaml'
+  createdTime:
+    $ref: '../../common/models/datetime.v1.yaml'
+  startAt:
+    $ref: '../../common/models/datetime.v1.yaml'
+  endAt:
+    $ref: '../../common/models/datetime.v1.yaml'
+required:
+  - id
+  - userId
+  - digestMD5
+  - mediaType
+  - size
+  - createdTime
+  - startAt
+  - endAt

--- a/reference/blob/models/device-logs-metadatalist.v1.yaml
+++ b/reference/blob/models/device-logs-metadatalist.v1.yaml
@@ -1,0 +1,6 @@
+title: Device logs blob list
+type: array
+readOnly: true
+minItems: 0
+items:
+  $ref: './device-logs-metadata.v1.yaml'

--- a/reference/blob/parameters/end-at.v1.yaml
+++ b/reference/blob/parameters/end-at.v1.yaml
@@ -1,0 +1,7 @@
+description: >-
+  End At Datetime
+name: endAt
+in: query
+required: true
+schema:
+  $ref: '../../common/models/datetime.v1.yaml'

--- a/reference/blob/parameters/end-at.v1.yaml
+++ b/reference/blob/parameters/end-at.v1.yaml
@@ -1,6 +1,6 @@
 description: >-
   End At Datetime
-name: endAt
+name: endAtTime
 in: query
 required: true
 schema:

--- a/reference/blob/parameters/start-at.v1.yaml
+++ b/reference/blob/parameters/start-at.v1.yaml
@@ -1,6 +1,6 @@
 description: >-
   Start At Datetime
-name: startAt
+name: startAtTime
 in: query
 required: true
 schema:

--- a/reference/blob/parameters/start-at.v1.yaml
+++ b/reference/blob/parameters/start-at.v1.yaml
@@ -1,0 +1,7 @@
+description: >-
+  Start At Datetime
+name: startAt
+in: query
+required: true
+schema:
+  $ref: '../../common/models/datetime.v1.yaml'


### PR DESCRIPTION
As discussed we reuse a lot of the existing blob api logic with a few minor differences in structure, a separate endpoint url, and with the introduction of startAt and endAt which must be provided by the client, as we do not particularly care about the structure of the data inside the blobs but would still like to be able to search through these blobs later on, should an incident require it.

The extra params are taken in as header params to keep the look and structure of the api as similar as possible to the existing endpoints. i.e. just upload data to the endpoint, like before, no multi-form content-type needed.