### PR TITLE
Fix documentation links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ install_tools:
 	./scripts/check_spec.sh --install
 	./scripts/merge_specs.sh --install
 	./scripts/publish.sh --install
-	./scripts/generate.sh --install
+	./scripts/generate_clinic.sh --install
 
 .PHONY: check
 check: check_tools check_files check_toc
@@ -117,7 +117,7 @@ check_tools:
 	./scripts/check_spec.sh --self-check
 	./scripts/merge_specs.sh --self-check
 	./scripts/publish.sh --self-check
-	./scripts/generate.sh --self-check
+	./scripts/generate_clinic.sh --self-check
 
 .PHONY: check_env
 check_env: check_public_env check_private_env
@@ -142,8 +142,9 @@ check_docs: $(SOURCE_DOCS)
 $(SOURCE_DOCS):
 	./scripts/check_doc.sh $@
 
+# check spec files, plus try to generate code from them
 .PHONY: check_specs
-check_specs: $(SOURCE_SPECS)
+check_specs: $(SOURCE_SPECS) generate_clinic_service
 
 # these are not really phony, just designating them as such to force Make to run the check tool
 .PHONY: $(SOURCE_SPECS)

--- a/docs/device-data/data-types/device-event/alarm.md
+++ b/docs/device-data/data-types/device-event/alarm.md
@@ -16,7 +16,7 @@
 ## Quick Summary
 
 ```yaml json_schema
-$ref: '../../../../reference/data/models/devicealarm.v1.yaml'
+$ref: '../../../../reference/data/models/deviceevent/alarm.v1.yaml'
 ```
 
 ---

--- a/docs/device-data/data-types/device-event/calibration.md
+++ b/docs/device-data/data-types/device-event/calibration.md
@@ -14,7 +14,7 @@
 ## Quick Summary
 
 ```yaml json_schema
-$ref: '../../../../reference/data/models/devicecalibration.v1.yaml'
+$ref: '../../../../reference/data/models/deviceevent/calibration.v1.yaml'
 ```
 
 ---

--- a/docs/device-data/data-types/device-event/prime.md
+++ b/docs/device-data/data-types/device-event/prime.md
@@ -16,7 +16,7 @@
 ## Quick Summary
 
 ```yaml json_schema
-$ref: '../../../../reference/data/models/deviceprimeevent.v1.yaml'
+$ref: '../../../../reference/data/models/deviceevent/prime.v1.yaml'
 ```
 
 ---

--- a/docs/device-data/data-types/device-event/reservoir-change.md
+++ b/docs/device-data/data-types/device-event/reservoir-change.md
@@ -15,7 +15,7 @@
 ## Quick Summary
 
 ```yaml json_schema
-$ref: '../../../../reference/data/models/devicereservoirchange.v1.yaml'
+$ref: '../../../../reference/data/models/deviceevent/reservoirchange.v1.yaml'
 ```
 
 ---

--- a/docs/device-data/data-types/device-event/sensor-event.md
+++ b/docs/device-data/data-types/device-event/sensor-event.md
@@ -6,7 +6,7 @@
 ## Quick Summary
 
 ```yaml json_schema
-$ref: '../../../../reference/data/models/devicesensorevent.v1.yaml'
+$ref: '../../../../reference/data/models/deviceevent/sensor.v1.yaml'
 ```
 
 ---

--- a/docs/device-data/data-types/device-event/settings-change.md
+++ b/docs/device-data/data-types/device-event/settings-change.md
@@ -6,7 +6,7 @@
 ## Quick Summary
 
 ```yaml json_schema
-$ref: '../../../../reference/data/models/devicesettingschange.v1.yaml'
+$ref: '../../../../reference/data/models/deviceevent/settingschange.v1.yaml'
 ```
 
 An event that occurs when a device has switched to a different setting.

--- a/docs/device-data/data-types/device-event/status.md
+++ b/docs/device-data/data-types/device-event/status.md
@@ -18,7 +18,7 @@
 ## Quick Summary
 
 ```yaml json_schema
-$ref: '../../../../reference/data/models/devicedeliverystatus.v1.yaml'
+$ref: '../../../../reference/data/models/deviceevent/deliverystatus.v1.yaml'
 ```
 
 ---

--- a/docs/device-data/data-types/device-event/time-change.md
+++ b/docs/device-data/data-types/device-event/time-change.md
@@ -15,7 +15,7 @@
 ## Quick Summary
 
 ```yaml json_schema
-$ref: '../../../../reference/data/models/devicetimechange.v1.yaml'
+$ref: '../../../../reference/data/models/deviceevent/timechange.v1.yaml'
 ```
 
 ---

--- a/docs/device-data/data-types/device-status.md
+++ b/docs/device-data/data-types/device-status.md
@@ -2,7 +2,7 @@
 # Device Status (`deviceStatus`)
 
 ```yaml json_schema
-$ref: '../../../reference/data/models/devicestatus.v1.yaml'
+$ref: '../../../reference/data/models/deviceevent/status.v1.yaml'
 ```
 
 This type is used to convey the status of a device.

--- a/docs/device-data/data-types/pump-settings/calculator.md
+++ b/docs/device-data/data-types/pump-settings/calculator.md
@@ -20,7 +20,7 @@
 ## Quick Summary
 
 ```yaml json_schema
-$ref: '../../../../reference/data/models/calculator.v1.yaml'
+$ref: '../../../../reference/data/models/bolus/calculator.v1.yaml'
 ```
 
 ---

--- a/reference/data/models/deviceevent/status.v1.yaml
+++ b/reference/data/models/deviceevent/status.v1.yaml
@@ -1,0 +1,34 @@
+title: 'DeviceStatusEvent'
+description: >-
+  A device status event.
+allOf:
+  - $ref: './event.v1.yaml'
+  - type: object
+    properties:
+      subType:
+        type: string
+        enum:
+          - status
+      duration:
+        type: number
+        format: integer
+        minimum: 0
+      expectedDuration:
+        type: number
+        format: integer
+        minimum: 0
+      status:
+        type: string
+        enum:
+          - suspended
+          - resumed
+      reason:
+        $ref: '../metadata.v1.yaml'
+    required:
+      - subType
+      - duration
+      - expectedDuration
+      - status
+      - reason
+x-tags:
+  - Data

--- a/scripts/check_doc.sh
+++ b/scripts/check_doc.sh
@@ -1,0 +1,30 @@
+#!/bin/sh -e
+
+trace() {
+    echo + $*
+    $*
+}
+
+case $1 in
+	-h | --help)
+		echo "usage: $(basename $0) [-h | --help] | [-i | --install] | [-c | --self-check] | {doc-filename}"
+		;;
+
+    -i | --install)
+        trace npm --version
+        trace npm install --location=global markdownlint-cli@0.33.0
+        trace npm install --location=global markdown-link-check@3.10.3
+        exit 0
+        ;;
+
+    -c | --self-check)
+        trace markdownlint --version
+        trace markdown-link-check --version
+        exit 0
+        ;;
+
+    *)
+        trace markdownlint $1
+        trace markdown-link-check $1
+        trace $(dirname $0)/check_ref_links.sh $1
+esac

--- a/scripts/check_ref_links.sh
+++ b/scripts/check_ref_links.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+echo "checking \$ref links in $1:"
+awk '/\$ref:/ { print $2 }' $1 | xargs -I% sh -c "cd $(dirname $1); ls -1 %"

--- a/scripts/check_spec.sh
+++ b/scripts/check_spec.sh
@@ -1,0 +1,33 @@
+#!/bin/sh -e
+
+trace() {
+    echo + $*
+    $*
+}
+
+case $1 in
+	-h | --help)
+		echo "usage: $(basename $0) [-h | --help] | [-i | --install] | [-c | --self-check] | {spec-filename}"
+		;;
+
+    -i | --install)
+        trace npm --version
+        trace npm install --location=global @stoplight/spectral-cli@6.6.0
+        trace npm install --location=global @apidevtools/swagger-cli@4.0.4
+        exit 0
+        ;;
+
+    -c | --self-check)
+        trace spectral --version
+        trace swagger-cli --version
+        exit 0
+        ;;
+
+    *)
+        if [ "$(dirname $1)" = "$(dirname $1 | cut -d/ -f1)" ]; then
+            trace swagger-cli validate $1
+            trace spectral lint --quiet $1
+        else
+            trace spectral lint --quiet --ignore-unknown-format $1
+        fi
+esac

--- a/scripts/generate_clinic.sh
+++ b/scripts/generate_clinic.sh
@@ -1,0 +1,40 @@
+#!/bin/sh -e
+
+trace() {
+    echo + $*
+    $*
+}
+
+case $1 in
+	-h | --help)
+		echo "usage: $(basename $0) [-h | --help] | [-i | --install] | [-c | --self-check] | {source-spec-filename} {bundled-spec-filename}"
+		;;
+
+    -i | --install)
+		trace npm --version
+		trace npm install --location=global @apidevtools/swagger-cli@4.0.4
+		trace go version
+		trace go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@latest
+        exit 0
+        ;;
+
+    -c | --self-check)
+        trace swagger-cli --version
+        trace oapi-codegen --version
+        exit 0
+        ;;
+
+    *)
+        source=$1
+		bundled=$2
+        server=$(dirname $bundled)/server
+        client=$(dirname $bundled)/client
+        common="--old-config-style --exclude-tags=Confirmations --package=api"
+		trace swagger-cli bundle $source -o $bundled -t yaml
+        trace mkdir -p $server $client
+		trace oapi-codegen $common --generate=server -o $server/gen_server.go $bundled
+		trace oapi-codegen $common --generate=spec -o $server/gen_spec.go $bundled
+		trace oapi-codegen $common --generate=types -o $server/gen_types.go $bundled
+        trace oapi-codegen $common --generate=types -o $client/types.go $bundled
+	    trace oapi-codegen $common --generate=client -o $client/client.go $bundled
+esac

--- a/scripts/merge_specs.sh
+++ b/scripts/merge_specs.sh
@@ -1,0 +1,42 @@
+#!/bin/sh -e
+
+trace() {
+    echo + $*
+    $*
+}
+
+case $1 in
+	-h | --help)
+		echo "usage: $(basename $0) [-h | --help] | [-i | --install] | [-c | --self-check] | {merged-spec-filename}"
+		;;
+
+    -i | --install)
+		case $(uname -s) in
+			Darwin)
+                trace brew --version
+        		trace brew install jsonnet@0.19.1
+                ;;
+			Linux)
+                trace go version
+				trace go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+                ;;
+		esac
+        trace npm install --location=global openapi-merge-cli@1.3.1
+        exit 0
+        ;;
+
+    -c | --self-check)
+        trace jsonnet --version
+        trace openapi-merge-cli --version
+        exit 0
+        ;;
+
+    *)
+		trace jsonnet --ext-str excludeTags="$2" \
+			--ext-str sourceFolder=./ \
+			--ext-str outputFile=$(basename $1) \
+			--output-file $(dirname $1)/openapi-merge.json \
+			./templates/openapi-merge.jsonnet
+        cd $(dirname $1)
+        trace openapi-merge-cli
+esac

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -e
+
+trace() {
+    echo + $*
+    $*
+}
+
+case $1 in
+	--help)
+		echo "usage: $(basename $0) [-h | --help] | [-i | --install] | [-c | --self-check] | {folder} {token}"
+		;;
+
+    --install)
+		trace npm --version
+		trace npm install --location=global @stoplight/cli@6.0.1280
+        exit 0
+        ;;
+
+    --self-check)
+        trace stoplight --version
+        exit 0
+        ;;
+
+    *)
+		find $1 -maxdepth 1 \( \( -type l -and -iname '*.yaml' \) -or -iname 'openapi*.json' \) -print -delete
+		trace stoplight push --directory $1 --ci-token $2
+esac


### PR DESCRIPTION
This PR fixes several broken data model links:
- Files that were moved around on July 26, 2021: https://github.com/tidepool-org/TidepoolApi/commit/1f928a4f950230f101b1b93da7281d69b3291e41
- Adds missing status.v1.yaml
- Re-structure & simplify Makefile by breaking it up into re-useable shell scripts that can be invoked independently for the various tasks
- Include the clinic service code generation task in the check_specs target to ensure that the changes do not break that repo