### PR TITLE
Move bolus calculator, smbg and upload data types up a level.

### DIFF
--- a/docs/datetime/btutc/usage.md
+++ b/docs/datetime/btutc/usage.md
@@ -75,7 +75,7 @@ _.each(data, function(datum) {
 
 ## Tracking The Time Generation Method
 
-Each instance of the Timezone Offset Utility keeps track of which method for generating the time field is being employed — BtUTC or [across-the-board application](../btutc.md#acrosstheboard-timezone-default) of a timezone. The method of time generation is publicly available through the type property on the instance (i.e. `cfg.tzoUtil.type`) and must be retrieved and provided as the time processing field of [upload metadata](../../device-data/data-types/pump-settings/upload.md).
+Each instance of the Timezone Offset Utility keeps track of which method for generating the time field is being employed — BtUTC or [across-the-board application](../btutc.md#acrosstheboard-timezone-default) of a timezone. The method of time generation is publicly available through the type property on the instance (i.e. `cfg.tzoUtil.type`) and must be retrieved and provided as the time processing field of [upload metadata](../../device-data/data-types/upload.md).
 
 ---
 

--- a/docs/device-data/annotations.md
+++ b/docs/device-data/annotations.md
@@ -19,7 +19,7 @@ Tidepool strives for complete accuracy in the data uploaded to Platform. In some
 
 ## Syntax And Annotation Conventions
 
-In the Tidepool data model, annotations is an optional property that may appear on any type in the data model, with the exception of [upload](./data-types/pump-settings/upload.md) (which is more of a metadata container). Annotations itself is an array of objects, where each object represents an individual annotation.
+In the Tidepool data model, annotations is an optional property that may appear on any type in the data model, with the exception of [upload](./data-types/upload.md) (which is more of a metadata container). Annotations itself is an array of objects, where each object represents an individual annotation.
 
 An annotation object must have a code property, and the typical construction of this code property is: `[manufacturer]/(datatype)/(description)`. The manufacturer prefix is optional and only present if the reason for annotation is manufacturer-specific. The data type (e.g. basal or bolus) provides another level of annotation namespacing. A descriptive and hyphen-delimited string should come last in the annotation code.
 

--- a/docs/device-data/data-types.md
+++ b/docs/device-data/data-types.md
@@ -11,7 +11,9 @@ This documents the diabetes device data types that Platform reads and stores. Al
 * [Basal Insulin](./data-types/basal.md)
 * [Bolus Insulin](./data-types/bolus.md)
 * [Blood Ketones](./data-types/blood-ketones.md)
+* [Bolus Calculator (wizard)](./data-types/calculator.md)
 * [Continuous Blood Glucose (CBG)](./data-types/cbg.md)
+* [Self-Monitored Blood Glucose (SMBG)](./data-types/smbg.md)
 * [CGM Settings](./data-types/cgm-settings.md)
 * [Controller Settings](./data-types/controller-settings.md)
 * [Controller Status](./data-types/controller-status.md)
@@ -20,9 +22,7 @@ This documents the diabetes device data types that Platform reads and stores. Al
 * [Dosing Decision](./data-types/dosing-decision.md)
 * [Pump Settings](./data-types/pump-settings.md)
 * [Pump Status](./data-types/pump-status.md)
-* [Bolus Calculator (wizard)](./data-types/pump-settings/calculator.md)
-* [Self-Monitored Blood Glucose (SMBG)](./data-types/pump-settings/smbg.md)
-* [Upload Metadata](./data-types/pump-settings/upload.md)
+* [Upload Metadata](./data-types/upload.md)
 
 <!-- theme: info -->
 

--- a/docs/device-data/data-types/calculator.md
+++ b/docs/device-data/data-types/calculator.md
@@ -20,7 +20,7 @@
 ## Quick Summary
 
 ```yaml json_schema
-$ref: '../../../../reference/data/models/bolus/calculator.v1.yaml'
+$ref: '../../../reference/data/models/bolus/calculator.v1.yaml'
 ```
 
 ---
@@ -33,7 +33,7 @@ $ref: '../../../../reference/data/models/bolus/calculator.v1.yaml'
 
 The Tidepool bolus calculator event models user interactions with a bolus calculator. The bolus calculator event is intended to contain the values that were input into the `wizard`, as well as any recommendations that the calculator may have made. (This event does not automatically record whether the recommendations made were followed.)
 
-Some insulin pumps record every user interaction with the bolus calculator, regardless of whether a bolus resulted from the interaction or not. However, only user interactions with the bolus calculator *that result in a bolus event* should be uploaded to Platform, to avoid noise in the data. The resulting bolus should also be included on the bolus calculator event — see [linking events](../../linking-events.md) for details.
+Some insulin pumps record every user interaction with the bolus calculator, regardless of whether a bolus resulted from the interaction or not. However, only user interactions with the bolus calculator *that result in a bolus event* should be uploaded to Platform, to avoid noise in the data. The resulting bolus should also be included on the bolus calculator event — see [linking events](../linking-events.md) for details.
 
 ---
 
@@ -47,7 +47,7 @@ Like all blood glucose-related fields, the BG input should be uploaded in either
 
 Only bolus calculator events that result in a bolus should be uploaded to Platform. When uploading through Platform, the bolus should only be submitted embedded within the appropriate bolus calculator event.
 
-See [linking events](../../linking-events.md) for more details on how events of different types are linked in Platform.
+See [linking events](../linking-events.md) for more details on how events of different types are linked in Platform.
 
 ---
 
@@ -65,7 +65,7 @@ Some devices have a separate field to enter a carbohydrate value on their bolus 
 
 ## Insulin-To-Carb Ratio (`insulinCarbRatio`)
 
-The insulin-to-carb (I:C) ratio is part of an insulin pump's settings. A user may program one I:C ratio to be used across-the-board, or particular ratios on a schedule per each 24-hour day. For more information on these persistent I:C ratios, see [carb ratios](../pump-settings.md#carb-ratio-carbratio).
+The insulin-to-carb (I:C) ratio is part of an insulin pump's settings. A user may program one I:C ratio to be used across-the-board, or particular ratios on a schedule per each 24-hour day. For more information on these persistent I:C ratios, see [carb ratios](./pump-settings.md#carb-ratio-carbratio).
 
 Most pumps make it possible to change the I:C for the bolus *currently being calculated*, without also changing the pump settings. Therefore, the insulin-to-carb ratio value on a bolus calculation may not always match the expected ratio given the user's insulin pump settings at the time of the calculation.
 
@@ -218,10 +218,10 @@ Net is the net number of units of insulin the bolus calculator recommended given
 
 ## Keep Reading
 
-* [Common Fields](../../common-fields.md)
-* [Datetime Guide](../../../datetime.md)
-* [Diabetes Data Types](../../data-types.md)
-* [Pump Settings](../pump-settings.md)
+* [Common Fields](../common-fields.md)
+* [Datetime Guide](../../datetime.md)
+* [Diabetes Data Types](../data-types.md)
+* [Pump Settings](./pump-settings.md)
 * [Self-Monitored Glucose (SMBG)](./smbg.md)
-* [Units](../../units.md)
+* [Units](../units.md)
 * [Upload Metadata](./upload.md)

--- a/docs/device-data/data-types/cbg.md
+++ b/docs/device-data/data-types/cbg.md
@@ -91,5 +91,5 @@ The device time field is only optional for *this* data type. This is because Tid
 * [CGM Settings](./cgm-settings.md)
 * [Common Fields](../common-fields.md)
 * [Pump Settings](./pump-settings.md)
-* [Self-Monitored Glucose (SMBG)](./pump-settings/smbg.md)
+* [Self-Monitored Glucose (SMBG)](./smbg.md)
 * [Units](../units.md)

--- a/docs/device-data/data-types/pump-settings.md
+++ b/docs/device-data/data-types/pump-settings.md
@@ -613,11 +613,11 @@ The blood glucose value may be mg/dL or mmol/L, but Platform will convert all bl
 
 ## Keep Reading
 
-* [Bolus Calculator](./pump-settings/calculator.md)
+* [Bolus Calculator](./calculator.md)
 * [Pump Settings Override](./device-event/pump-settings-override.md)
 * [Common Fields](../common-fields.md)
 * [Datetime Guide](../../datetime.md)
 * [Diabetes Data Types](../data-types.md)
-* [Self-Monitored Glucose (SMBG)](./pump-settings/smbg.md)
+* [Self-Monitored Glucose (SMBG)](./smbg.md)
 * [Units](../units.md)
-* [Upload Metadata](./pump-settings/upload.md)
+* [Upload Metadata](./upload.md)

--- a/docs/device-data/data-types/smbg.md
+++ b/docs/device-data/data-types/smbg.md
@@ -15,14 +15,14 @@
 ## Quick Summary
 
 ```yaml json_schema
-$ref: '../../../../reference/data/models/blood/selfmonitoredglucose.v1.yaml'
+$ref: '../../../reference/data/models/blood/selfmonitoredglucose.v1.yaml'
 ```
 
 ---
 
 ## Type (`type`)
 
-This is the Tidepool data type for traditional fingerstick blood glucose meter data. SMBG is an abbreviation of "self-monitored blood glucose" and contrasts with CBG, abbreviating "continuous blood glucose." CBG is the [Tidepool data type for continuous glucose monitor](../cgm-settings.md) (CGM) sensor data.
+This is the Tidepool data type for traditional fingerstick blood glucose meter data. SMBG is an abbreviation of "self-monitored blood glucose" and contrasts with CBG, abbreviating "continuous blood glucose." CBG is the [Tidepool data type for continuous glucose monitor](./cgm-settings.md) (CGM) sensor data.
 
 ---
 
@@ -100,9 +100,9 @@ The linked value indicates that the blood glucose value was transferred from a b
 ## Keep Reading
 
 * [Bolus Calculator](./calculator.md)
-* [Common Fields](../../common-fields.md)
-* [Datetime Guide](../../../datetime.md)
-* [Diabetes Data Types](../../data-types.md)
-* [Pump Settings](../pump-settings.md)
-* [Units](../../units.md)
+* [Common Fields](../common-fields.md)
+* [Datetime Guide](../../datetime.md)
+* [Diabetes Data Types](../data-types.md)
+* [Pump Settings](./pump-settings.md)
+* [Units](../units.md)
 * [Upload Metadata](./upload.md)

--- a/docs/device-data/data-types/upload.md
+++ b/docs/device-data/data-types/upload.md
@@ -24,7 +24,7 @@
 ## Quick Summary
 
 ```yaml json_schema
-$ref: '../../../../reference/data/models/upload.v1.yaml'
+$ref: '../../../reference/data/models/upload.v1.yaml'
 ```
 
 ---
@@ -223,9 +223,9 @@ A string identifying the software version of the uploading client. For Tidepool 
 ## Keep Reading
 
 * [Bolus Calculator](./calculator.md)
-* [Common Fields](../../common-fields.md)
-* [Datetime Guide](../../../datetime.md)
-* [Diabetes Data Types](../../data-types.md)
-* [Pump Settings](../pump-settings.md)
+* [Common Fields](../common-fields.md)
+* [Datetime Guide](../../datetime.md)
+* [Diabetes Data Types](../data-types.md)
+* [Pump Settings](./pump-settings.md)
 * [Self-Monitored Glucose (SMBG)](./smbg.md)
-* [Units](../../units.md)
+* [Units](../units.md)

--- a/docs/device-data/linking-events.md
+++ b/docs/device-data/linking-events.md
@@ -91,7 +91,7 @@ The resulting data looks like:
 
 * [Alarm](./data-types/device-event/alarm.md)
 * [Bolus](./data-types/bolus.md)
-* [Bolus Calculator](./data-types/pump-settings/calculator.md)
+* [Bolus Calculator](./data-types/calculator.md)
 * [Common Fields](./common-fields.md)
 * [Reservoir Change](./data-types/device-event/reservoir-change.md)
 * [Status](./data-types/device-event/status.md)

--- a/docs/device-data/oor-values.md
+++ b/docs/device-data/oor-values.md
@@ -116,4 +116,4 @@ In this instance, because the threshold was unknown, we used a value that we kne
 * [Blood Ketones](./data-types/blood-ketones.md)
 * [Continuous Blood Glucose (CBG)](./data-types/cbg.md)
 * [CGM Settings](./data-types/cgm-settings.md)
-* [Self-Monitored Glucose (SMBG)](./data-types/pump-settings/smbg.md)
+* [Self-Monitored Glucose (SMBG)](./data-types/smbg.md)

--- a/toc.json
+++ b/toc.json
@@ -199,6 +199,11 @@
               "uri": "docs/device-data/data-types/blood-ketones.md"
             },
             {
+              "type": "item",
+              "title": "Bolus Calculator Records (`wizard`)",
+              "uri": "docs/device-data/data-types/calculator.md"
+            },
+            {
               "type": "group",
               "title": "Bolus Insulin (`bolus`)",
               "items": [
@@ -233,6 +238,11 @@
               "type": "item",
               "title": "Continuous Blood Glucose (`cbg`)",
               "uri": "docs/device-data/data-types/cbg.md"
+            },
+            {
+              "type": "item",
+              "title": "Self-Monitored Blood Glucose (`smbg`)",
+              "uri": "docs/device-data/data-types/smbg.md"
             },
             {
               "type": "item",
@@ -316,35 +326,19 @@
               "uri": "docs/device-data/data-types/dosing-decision.md"
             },
             {
-              "type": "group",
+              "type": "item",
               "title": "Pump Settings (`pumpSettings`)",
-              "items": [
-                {
-                  "type": "item",
-                  "title": "Overview",
-                  "uri": "docs/device-data/data-types/pump-settings.md"
-                },
-                {
-                  "type": "item",
-                  "title": "Bolus Calculator Records (`wizard`)",
-                  "uri": "docs/device-data/data-types/pump-settings/calculator.md"
-                },
-                {
-                  "type": "item",
-                  "title": "Self-Monitored Blood Glucose (`smbg`)",
-                  "uri": "docs/device-data/data-types/pump-settings/smbg.md"
-                },
-                {
-                  "type": "item",
-                  "title": "Upload Metadata (`upload`)",
-                  "uri": "docs/device-data/data-types/pump-settings/upload.md"
-                }
-              ]
+              "uri": "docs/device-data/data-types/pump-settings.md"
             },
             {
               "type": "item",
               "title": "Pump Status (`pumpStatus`)",
               "uri": "docs/device-data/data-types/pump-status.md"
+            },
+            {
+              "type": "item",
+              "title": "Upload Metadata (`upload`)",
+              "uri": "docs/device-data/data-types/upload.md"
             }
           ]
         },


### PR DESCRIPTION
They do not belong under pump settings.

Re-align cross-ref links in other files and the TOC to the new location.