### PR TITLE
tjotala/buildfix - fixing API docs publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ jobs:
     strategy:
       matrix:
         target: [ publish_public, publish_private ]
+      # it seems like the Stoplight CLI may choke on parallel pushes, so force these to run sequentially
+      max-parallel: 1
+      fail-fast: true
     runs-on: ubuntu-latest
     env:
       PUBLIC_STOPLIGHT_TOKEN: ${{ secrets.PUBLIC_STOPLIGHT_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ $(SOURCE_DOCS):
 
 # check spec files, plus try to generate code from them
 .PHONY: check_specs
-check_specs: $(SOURCE_SPECS) generate_clinic_service
+check_specs: $(SOURCE_SPECS_TOP_LEVEL) generate_clinic_service
 
 # these are not really phony, just designating them as such to force Make to run the check tool
 .PHONY: $(SOURCE_SPECS)

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ SOURCE_TOC = toc.json
 SOURCE_TOC_DOCS = ${shell awk '/"uri":.+\.md/ { print $$2 }' $(SOURCE_TOC) | tr '\n"' ' ' | sort}
 SOURCE_DOCS = ${shell find $(DOC_FOLDER) -type f -iname '*.md' | sort}
 SOURCE_SPECS = ${shell find $(SPEC_FOLDER) -type f -iname '*.yaml' | sort}
-SOURCE_SPECS_TOP_LEVEL = ${shell find $(SPEC_FOLDER) -mindepth 1 -maxdepth 1 \( -type d -or -iname '*.yaml' \) | sort}
+SOURCE_SPECS_TOP_LEVEL = ${shell find $(SPEC_FOLDER) -maxdepth 1 -type f -iname '*.yaml' | sort}
 MERGED_SPEC = combined.v1.yaml
 SOURCE_ASSETS = ${shell find $(ASSET_FOLDER) -type f -iname '*.png' | sort}
 
@@ -108,6 +108,7 @@ $(BUILD_FOLDER) $(PUBLIC_FOLDER) $(PUBLIC_SPEC_FOLDER) $(PRIVATE_FOLDER) $(PRIVA
 install_tools:
 	./scripts/check_doc.sh --install
 	./scripts/check_spec.sh --install
+	./scripts/bundle_spec.sh --install
 	./scripts/merge_specs.sh --install
 	./scripts/publish.sh --install
 	./scripts/generate_clinic.sh --install
@@ -119,6 +120,7 @@ check: check_tools check_files check_toc
 check_tools:
 	./scripts/check_doc.sh --self-check
 	./scripts/check_spec.sh --self-check
+	./scripts/bundle_spec.sh --self-check
 	./scripts/merge_specs.sh --self-check
 	./scripts/publish.sh --self-check
 	./scripts/generate_clinic.sh --self-check
@@ -231,7 +233,7 @@ $(PUBLIC_MERGED_SPEC): $(PUBLIC_SPECS) | $(PUBLIC_SPEC_FOLDER)
 	./scripts/merge_specs.sh $@ Internal
 
 $(PUBLIC_SPECS): | $(PUBLIC_SPEC_FOLDER)
-	ln -sf ${abspath ${subst $(PUBLIC_SPEC_FOLDER),$(SPEC_FOLDER),$@}} $@
+	./scripts/bundle_spec.sh ${abspath ${subst $(PUBLIC_SPEC_FOLDER),$(SPEC_FOLDER),$@}} $@
 
 .PHONY: private_specs
 private_specs: $(PRIVATE_MERGED_SPEC)
@@ -240,7 +242,7 @@ $(PRIVATE_MERGED_SPEC): $(PRIVATE_SPECS) | $(PRIVATE_SPEC_FOLDER)
 	./scripts/merge_specs.sh $@
 
 $(PRIVATE_SPECS): | $(PRIVATE_SPEC_FOLDER)
-	ln -sf ${abspath ${subst $(PRIVATE_SPEC_FOLDER),$(SPEC_FOLDER),$@}} $@
+	./scripts/bundle_spec.sh ${abspath ${subst $(PRIVATE_SPEC_FOLDER),$(SPEC_FOLDER),$@}} $@
 
 .PHONY: public_assets
 public_assets: $(PUBLIC_ASSET_FOLDER)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The contents in Tidepool's organization [home page](https://tidepool.stoplight.i
 
 ## Other Tools
 
-The [Makefile](./Makefile) makes use of several tools to check, prepare, and publish the documentation and specifications.
+The [Makefile](./Makefile) makes use of several CLI tools to check, prepare, and publish the documentation and specifications.
 You can install the tools by executing the following command:
 
 ```shell
@@ -113,6 +113,7 @@ make check_tools
 | [markdown-link-check](https://www.npmjs.com/package/markdown-link-check) | Validates hyperlinks in Markdown files. |
 | [spectral](https://www.npmjs.com/package/@stoplight/spectral) | Validates OpenAPI 3.0 specification files. |
 | [swagger-cli](https://www.npmjs.com/package/swagger-cli) | Validates OpenAPI 3.0 specification files. Also bundles multiple OAS3 files into a single file, that is required by some downstream use-cases. |
+| [redocly](https://github.com/Redocly/redocly-cli) | Validates OpenAPI 3.0 specification files. Also bundles multiple OAS3 files into a single file, that is required by some downstream use-cases. |
 | [jsonnet](https://jsonnet.org/) | Data templating tool. Used here to generate the configuration file for `openapi-merge-cli`. |
 | [openapi-merge-cli](https://www.npmjs.com/package/openapi-merge-cli) | Merges OpenAPI 3.0 specification files into single file. |
 | [stoplight](https://www.npmjs.com/package/@stoplight/cli) | Publishes OpenAPI 3.0 specifications and documentation in Markdown format to Stoplight's web site. |

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,6 @@
+extends:
+  - recommended
+rules:
+  no-ambiguous-paths: off
+  operation-2xx-response: off
+  operation-4xx-response: off

--- a/reference/auth.v1.yaml
+++ b/reference/auth.v1.yaml
@@ -100,6 +100,7 @@ paths:
       responses:
         '200':
           description: 'Success'
+      security: []
       tags:
         - Authentication
       deprecated: true
@@ -148,6 +149,7 @@ paths:
           $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
+      security: []
       tags:
         - Users
       deprecated: true
@@ -363,6 +365,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/ServerError'
+      security: []
       tags:
         - Authentication
         - Internal

--- a/reference/auth.v2.yaml
+++ b/reference/auth.v2.yaml
@@ -63,15 +63,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenErrorResponse'
-              examples:
-                Token Exchange - Duplicate Email Address:
-                  value:
-                    error: invalid_token
-                    error_description: User already exists
-                Token Exchange - Invalid Token:
-                  value:
-                    error: invalid_token
-                    error_description: invalid token
       description: |-
         Obtain an access, id and refresh token(s) by presenting an authorization grant or a valid refresh token.
 
@@ -91,16 +82,6 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/TokenRequest'
-            examples:
-              Token Exchange Request:
-                value:
-                  client_id: cgm-monitor
-                  client_secret: c50e6502-131c-47f0-b439-a43acb3b83d0
-                  grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange'
-                  subject_issuer: acme-clinic
-                  subject_token: eyJhbGciOiJ...
-                  subject_token_type: 'urn:ietf:params:oauth:token-type:access_token'
-                  requested_token_type: 'urn:ietf:params:oauth:token-type:refresh_token'
         description: ''
       tags:
         - Authentication v2
@@ -184,17 +165,7 @@ components:
   schemas:
     TokenRequest:
       title: Token Request
-      x-stoplight:
-        id: 4097e58bd9c0a
       type: object
-      examples:
-        - client_id: cgm-monitor
-          client_secret: c50e6502-131c-47f0-b439-a43acb3b83d0
-          grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange'
-          subject_issuer: acme-clinic
-          subject_token: eyJhbGciOiJ...
-          subject_token_type: 'urn:ietf:params:oauth:token-type:access_token'
-          requested_token_type: 'urn:ietf:params:oauth:token-type:refresh_token'
       properties:
         code:
           type: string
@@ -213,15 +184,19 @@ components:
             `authorization_code` - used in the authorization code flow
             `refresh_token` - used for refreshing expired access tokens with an active refresh token
             `urn:ietf:params:oauth:grant-type:token-exchange` - used in the token exchange flow
+          example: 'urn:ietf:params:oauth:grant-type:token-exchange'
         client_id:
           type: string
-          description: The client id
+          description: The client ID
+          example: cgm-monitor
         client_secret:
           type: string
           description: The client secret if the client is confidential or it was issued credentials.
+          example: c50e6502-131c-47f0-b439-a43acb3b83d0
         subject_token:
           type: string
           description: 'The subject token used in the token exchange flow. `REQUIRED` when `grant_type` is `urn:ietf:params:oauth:grant-type:token-exchange`'
+          example: eyJhbGciOiJ...
         subject_token_type:
           type: string
           enum:
@@ -233,23 +208,24 @@ components:
             If the type is `urn:ietf:params:oauth:token-type:access_token` you must specify the `subject_issuer` parameter and it must be the alias of the configured identity provider. If the type is `urn:ietf:params:oauth:token-type:jwt`, the provider will be matched via the issuer claim within the JWT which must be the alias of the provider, or a registered issuer within the providers configuration.
 
             For validation, if the token is an access token, the provider’s user info service will be invoked to validate the token. A successful call will mean that the access token is valid. If the subject token is a JWT and if the provider has signature validation enabled, that will be attempted, otherwise, it will default to also invoking on the user info service to validate the token.
+          example: 'urn:ietf:params:oauth:token-type:access_token'
         requested_token_type:
           type: string
           description: The type of token that will be issued in the token exhange flow.
           enum:
             - 'urn:ietf:params:oauth:token-type:access_token'
             - 'urn:ietf:params:oauth:token-type:refresh_token'
+          example: 'urn:ietf:params:oauth:token-type:refresh_token'
         subject_issuer:
           type: string
           description: 'The issuer of `subject_token`. It must be a registered identity provider. `REQUIRED` when `subject_token_type` is `urn:ietf:params:oauth:token-type:access_token`'
+          example: acme-clinic
       required:
         - grant_type
         - client_id
       description: ''
     TokenResponse:
       title: Token Response
-      x-stoplight:
-        id: assvu0xc9w7be
       type: object
       description: A successful token response
       properties:
@@ -257,45 +233,39 @@ components:
           type: string
           description: |
             A short-lived access token for the currently authenticated subject. 
+          example: ODBkOTY5NWUtN2I0Mi00ODQwLWI0ZTEtZDdmYjcwMjhhZWIyCg==
         expires_in:
           type: integer
           description: The number of seconds the access token expires in
+          example: 60
         refresh_expires_in:
-          type: string
+          type: integer
           description: The number of seconds the refresh token expires in
+          example: 7200
         refresh_token:
           type: string
           description: The refresh token that can be used to obtain a new access token for the subject after the previous one had expired.
+          example: ZWM0MGZjYzctMWExZC00NmM4LTlhOTgtOTVjOTYyNGFiNWZhCg==
         scope:
           type: string
           description: The authorized scopes
+          example: openid email
         id_token:
           type: string
           description: An ID token associated with the authenticated session. The value will only be returned if the `openid` scope was requested.
-      examples:
-        - access_token: the-access-token-value
-          expires_in: 60
-          refresh_expires_in: 7200
-          refresh_token: the-refresh-token-value
-          scope: openid email
-          id_token: the-id-token-value
+          example: MDY3YzJmMjctOTliMi00N2ZjLWFkMGUtMzY3NzliMmJiNGI1Cg==
     TokenErrorResponse:
       title: TokenErrorResponse
-      x-stoplight:
-        id: 4mxi6mxyc82rx
       type: object
       properties:
         error:
           type: string
           description: The error identifier
+          example: invalid_token
         error_description:
           type: string
           description: Description of the error that occurred
-      examples:
-        - error: invalid_token
-          error_description: invalid token
-        - error: invalid_token
-          error_description: User already exists
+          example: User already exists
   securitySchemes: {}
   requestBodies: {}
   parameters:

--- a/reference/auth.v2.yaml
+++ b/reference/auth.v2.yaml
@@ -18,6 +18,9 @@ info:
     url: 'https://support.tidepool.org/'
     email: support@tidepool.org
     name: API Support
+  license:
+    name: BSD-2-Clause
+    url: https://github.com/tidepool-org/shoreline/blob/master/LICENSE
   termsOfService: 'https://developer.tidepool.org/terms-of-use'
 servers:
   - url: 'https://external.integration.tidepool.org'
@@ -44,7 +47,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/realm'
     post:
-      security: [ ]
+      security: []
       summary: Obtain Token
       operationId: ObtainToken
       responses:
@@ -114,7 +117,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/realm'
     get:
-      security: [ ]
+      security: []
       summary: Authorize
       responses:
         '301':
@@ -311,3 +314,5 @@ components:
       description: 'The authentication realm. '
 tags:
   - name: Authentication v2
+    description: >-
+      Authentication APIs version 2.

--- a/reference/clinic.v1.yaml
+++ b/reference/clinic.v1.yaml
@@ -670,7 +670,7 @@ paths:
       - $ref: '#/components/parameters/clinicId'
       - $ref: '#/components/parameters/inviteId'
     patch:
-      summary: ''
+      summary: 'Resend Clinician Invite'
       operationId: ResendInvite
       responses:
         '200':
@@ -1037,7 +1037,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/userId'
     delete:
-      summary: ''
+      summary: 'Remove User from Clinics'
       operationId: DeleteUserFromClinics
       responses:
         '200':
@@ -1114,26 +1114,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PatientSummary'
-            examples:
-              example-1:
-                value:
-                  lastUpdatedDate: '2019-08-24T14:15:22Z'
-                  firstData: '2019-08-24T14:15:22Z'
-                  lastData: '2019-08-24T14:15:22Z'
-                  lastUploadDate: '2019-08-24T14:15:22Z'
-                  outdatedSince: '2019-08-24T14:15:22Z'
-                  averageGlucose:
-                    units: mmol/l
-                    value: 105
-                  glucoseManagementIndicator: 0.06
-                  percentTimeInTarget: 0.7
-                  percentTimeInHigh: 0.1
-                  percentTimeInVeryHigh: 0.1
-                  percentTimeInLow: 0.05
-                  percentTimeInVeryLow: 0.05
-                  percentTimeCGMUse: 0.9
-                  highGlucoseThreshold: 0
-                  lowGlucoseThreshold: 0
         description: ''
   '/v1/patients/{userId}/data_sources':
     parameters:

--- a/reference/clinic/models/clinicid.v1.yaml
+++ b/reference/clinic/models/clinicid.v1.yaml
@@ -6,3 +6,4 @@ minLength: 24
 maxLength: 24
 pattern: '^[a-f0-9]{24}$'
 readOnly: true
+example: 2fe2488217ee43e1b2e83c2f

--- a/reference/clinic/models/membershiprestriction.v1.yaml
+++ b/reference/clinic/models/membershiprestriction.v1.yaml
@@ -1,6 +1,4 @@
 title: Membership Restriction
-x-stoplight:
-  id: lkeikldmhqso2
 type: object
 description: A user joining a clinic must match all of the defined restrictions
 properties:

--- a/reference/clinic/models/membershiprestrictions.v1.yaml
+++ b/reference/clinic/models/membershiprestrictions.v1.yaml
@@ -1,6 +1,4 @@
 title: Membership Restrictions
-x-stoplight:
-  id: j8zuck3me7f8s
 type: object
 description: A user joining a clinic must match at least one of the specified membership restrictions
 properties:

--- a/reference/confirm.v1.yaml
+++ b/reference/confirm.v1.yaml
@@ -405,23 +405,8 @@ components:
     Acceptance:
       $ref: './confirm/models/acceptance.v1.yaml'
 
-    ClinicId:
-      $ref: './clinic/models/clinicid.v1.yaml'
-
-    EmailAddress:
-      $ref: ./common/models/emailaddress.v1.yaml
-
-    Key:
-      $ref: ./confirm/models/key.v1.yaml
-
     Password:
       $ref: ./common/models/password.v1.yaml
-
-    Birthday:
-      $ref: './common/models/birthday.v1.yaml'
-
-    Confirmation:
-      $ref: ./confirm/models/confirmation.v1.yaml
 
   parameters:
     userId:

--- a/reference/confirm.v1.yaml
+++ b/reference/confirm.v1.yaml
@@ -80,6 +80,7 @@ paths:
           $ref: '#/components/responses/ConfirmationError'
         '500':
           $ref: '#/components/responses/ConfirmationError'
+      security: []
       tags:
         - Confirmations
 
@@ -106,6 +107,7 @@ paths:
           $ref: '#/components/responses/ConfirmationError'
         '500':
           $ref: '#/components/responses/ConfirmationError'
+      security: []
       tags:
         - Confirmations
 
@@ -127,6 +129,7 @@ paths:
           $ref: '#/components/responses/ConfirmationError'
         '404':
           $ref: '#/components/responses/ConfirmationError'
+      security: []
       tags:
         - Confirmations
 
@@ -194,6 +197,7 @@ paths:
           $ref: '#/components/responses/ConfirmationError'
         '404':
           $ref: '#/components/responses/ConfirmationError'
+      security: []
       tags:
         - Confirmations
 
@@ -216,6 +220,7 @@ paths:
           $ref: '#/components/responses/ConfirmationSuccess'
         '400':
           $ref: '#/components/responses/ConfirmationError'
+      security: []
       tags:
         - Confirmations
 
@@ -241,6 +246,7 @@ paths:
           $ref: '#/components/responses/ConfirmationError'
         '404':
           $ref: '#/components/responses/ConfirmationError'
+      security: []
       tags:
         - Confirmations
 
@@ -293,6 +299,8 @@ paths:
           $ref: '#/components/responses/ConfirmationError'
         '500':
           $ref: '#/components/responses/ConfirmationError'
+      security:
+        - sessionToken: []
       tags:
         - Confirmations
 

--- a/reference/confirm/models/restrictions.v1.yaml
+++ b/reference/confirm/models/restrictions.v1.yaml
@@ -1,6 +1,4 @@
 title: Acceptance restrictions
-x-stoplight:
-  id: ywnkw0w7xn8b4
 type: object
 properties:
   canAccept:

--- a/reference/general.v1.yaml
+++ b/reference/general.v1.yaml
@@ -48,6 +48,7 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ClientVersions'
+      security: []
       tags:
         - General
         - Internal

--- a/reference/metrics.v1.yaml
+++ b/reference/metrics.v1.yaml
@@ -58,6 +58,8 @@ paths:
           description: >-
             Success
       operationId: RecordMetricsEventForNamedUser
+      security:
+        - sessionToken: []
       tags:
         - Metrics
 

--- a/reference/prescription.v1.yaml
+++ b/reference/prescription.v1.yaml
@@ -10,6 +10,7 @@ info:
   termsOfService: 'https://developer.tidepool.org/terms-of-use/'
   license:
     name: BSD 2-Clause "Simplified" License
+    url: https://github.com/tidepool-org/platform/master/LICENSE
 
 servers:
   - url: 'https://external.integration.tidepool.org'
@@ -35,6 +36,8 @@ paths:
   '/v1/clinics/{clinicId}/prescriptions':
     get:
       summary: List Prescriptions
+      security:
+        - sessionToken: []
       tags:
         - Prescriptions
       responses:
@@ -151,6 +154,8 @@ paths:
       description: Create a new prescription
       tags:
         - Prescriptions
+      security:
+        - sessionToken: []
       requestBody:
         content:
           application/json:
@@ -206,6 +211,8 @@ paths:
                 $ref: ./platform/models/errorresponse.v1.yaml
       operationId: GetPrescriptionById
       description: Retrieve a prescription by id
+      security:
+        - sessionToken: []
     delete:
       summary: Delete Prescription
       operationId: DeletePrescription
@@ -238,6 +245,8 @@ paths:
                 $ref: ./platform/models/errorresponse.v1.yaml
       description: >-
         Clinician only endpoint to delete a prescription. Works only when the prescription has status `draft`.
+      security:
+        - sessionToken: []
       tags:
         - Prescriptions
   '/v1/clinics/{clinicId}/prescriptions/{prescriptionId}/revisions':
@@ -293,6 +302,8 @@ paths:
               schema:
                 $ref: ./platform/models/errorresponse.v1.yaml
       description: Add a new revision to a prescription which is still a draft.
+      security:
+        - sessionToken: []
       tags:
         - Prescriptions
       requestBody:
@@ -342,6 +353,8 @@ paths:
             application/json:
               schema:
                 $ref: ./platform/models/errorresponse.v1.yaml
+      security:
+        - sessionToken: []
       tags:
         - Prescriptions
       description: Claim a submitted prescription using an access code and date of birth.
@@ -363,6 +376,8 @@ paths:
         '200':
           description: OK
       description: Retrieve a list of prescription that the user has claimed
+      security:
+        - sessionToken: []
       tags:
         - Prescriptions
   '/v1/patients/{userId}/prescriptions/{prescriptionId}':
@@ -390,6 +405,8 @@ paths:
                 $ref: ./prescription/models/prescription.v1.yaml
       operationId: GetPrescriptionForUser
       description: Retrieve a prescription by id
+      security:
+        - sessionToken: []
     patch:
       summary: Update Prescription State
       operationId: UpdatePrescriptionState
@@ -403,7 +420,11 @@ paths:
       description: Update prescription state
       tags:
         - Prescriptions
+      security:
+        - sessionToken: []
 components:
   schemas: {}
-  securitySchemes: {}
+  securitySchemes:
+    sessionToken:
+      $ref: './common/security/tidepoolsessiontoken.v1.yaml'
   parameters: {}

--- a/reference/prescription/models/calculator.v1.yaml
+++ b/reference/prescription/models/calculator.v1.yaml
@@ -1,7 +1,5 @@
 title: calculator.v1
 type: object
-x-examples:
-  example-1: {}
 description: ''
 properties:
   method:

--- a/reference/prescription/models/prescription.v1.yaml
+++ b/reference/prescription/models/prescription.v1.yaml
@@ -1,8 +1,6 @@
 title: Tidepool Loop Prescription
 type: object
 description: Object describing a Tidepool Loop Prescription
-x-examples:
-  example-1: {}
 properties:
   id:
     $ref: ../../common/models/objectid.v1.yaml
@@ -29,8 +27,7 @@ properties:
   latestRevision:
     $ref: ./revision.v1.yaml
   clinicId:
-    type: string
-    description: A string represation of a Tidepool Clinic Id
+    $ref: '../../clinic/models/clinicid.v1.yaml'
 required:
   - id
   - state

--- a/scripts/bundle_spec.sh
+++ b/scripts/bundle_spec.sh
@@ -1,0 +1,25 @@
+#!/bin/sh -e
+
+trace() {
+    echo + $*
+    $*
+}
+
+case $1 in
+	-h | --help)
+		echo "usage: $(basename $0) [-h | --help] | [-i | --install] | [-c | --self-check] | {source-spec} {bundle-spec}"
+		;;
+
+    -i | --install)
+        trace npm install --location=global @apidevtools/swagger-cli@4.0.4
+        exit 0
+        ;;
+
+    -c | --self-check)
+        trace swagger-cli --version
+        exit 0
+        ;;
+
+    *)
+		trace swagger-cli bundle --type yaml $1 --outfile $2
+esac

--- a/scripts/bundle_spec.sh
+++ b/scripts/bundle_spec.sh
@@ -21,5 +21,5 @@ case $1 in
         ;;
 
     *)
-		trace swagger-cli bundle --type yaml $1 --outfile $2
+		trace swagger-cli bundle --type yaml --dereference $1 --outfile $2
 esac

--- a/scripts/bundle_spec.sh
+++ b/scripts/bundle_spec.sh
@@ -11,7 +11,7 @@ case $1 in
 		;;
 
     -i | --install)
-        trace npm install --location=global @redocly/cli@1.0.0-beta.128
+        trace npm install -g @redocly/cli@1.0.0-rc.3
         exit 0
         ;;
 

--- a/scripts/bundle_spec.sh
+++ b/scripts/bundle_spec.sh
@@ -11,15 +11,15 @@ case $1 in
 		;;
 
     -i | --install)
-        trace npm install --location=global @apidevtools/swagger-cli@4.0.4
+        trace npm install --location=global @redocly/cli@1.0.0-beta.128
         exit 0
         ;;
 
     -c | --self-check)
-        trace swagger-cli --version
+        trace redocly --version
         exit 0
         ;;
 
     *)
-		trace swagger-cli bundle --type yaml --dereference $1 --outfile $2
+		trace redocly bundle $1 --output $2
 esac

--- a/scripts/check_doc.sh
+++ b/scripts/check_doc.sh
@@ -12,8 +12,8 @@ case $1 in
 
     -i | --install)
         trace npm --version
-        trace npm install --location=global markdownlint-cli@0.33.0
-        trace npm install --location=global markdown-link-check@3.10.3
+        trace npm install -g markdownlint-cli@0.33.0
+        trace npm install -g markdown-link-check@3.10.3
         exit 0
         ;;
 

--- a/scripts/check_spec.sh
+++ b/scripts/check_spec.sh
@@ -14,20 +14,19 @@ case $1 in
         trace npm --version
         trace npm install --location=global @stoplight/spectral-cli@6.6.0
         trace npm install --location=global @apidevtools/swagger-cli@4.0.4
+        trace npm install --location=global @redocly/cli@1.0.0-beta.128
         exit 0
         ;;
 
     -c | --self-check)
         trace spectral --version
         trace swagger-cli --version
+        trace redocly --version
         exit 0
         ;;
 
     *)
-        if [ "$(dirname $1)" = "$(dirname $1 | cut -d/ -f1)" ]; then
-            trace swagger-cli validate $1
-            trace spectral lint --quiet $1
-        else
-            trace spectral lint --quiet --ignore-unknown-format $1
-        fi
+        trace swagger-cli validate $1
+        trace spectral lint --quiet $1
+        trace redocly lint --format=codeframe $1
 esac

--- a/scripts/check_spec.sh
+++ b/scripts/check_spec.sh
@@ -12,9 +12,9 @@ case $1 in
 
     -i | --install)
         trace npm --version
-        trace npm install --location=global @stoplight/spectral-cli@6.6.0
-        trace npm install --location=global @apidevtools/swagger-cli@4.0.4
-        trace npm install --location=global @redocly/cli@1.0.0-beta.128
+        trace npm install -g @stoplight/spectral-cli@6.8.0
+        trace npm install -g @apidevtools/swagger-cli@4.0.4
+        trace npm install -g @redocly/cli@1.0.0-rc.3
         exit 0
         ;;
 

--- a/scripts/generate_clinic.sh
+++ b/scripts/generate_clinic.sh
@@ -12,7 +12,7 @@ case $1 in
 
     -i | --install)
 		trace npm --version
-		trace npm install --location=global @apidevtools/swagger-cli@4.0.4
+		trace npm install -g @apidevtools/swagger-cli@4.0.4
 		trace go version
 		trace go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@latest
         exit 0

--- a/scripts/merge_specs.sh
+++ b/scripts/merge_specs.sh
@@ -37,6 +37,6 @@ case $1 in
 			--ext-str outputFile=$(basename $1) \
 			--output-file $(dirname $1)/openapi-merge.json \
 			./templates/openapi-merge.jsonnet
-        cd $(dirname $1)
+        trace cd $(dirname $1)
         trace openapi-merge-cli
 esac

--- a/scripts/merge_specs.sh
+++ b/scripts/merge_specs.sh
@@ -14,14 +14,14 @@ case $1 in
 		case $(uname -s) in
 			Darwin)
                 trace brew --version
-        		trace brew install jsonnet@0.19.1
+        		trace brew install jsonnet
                 ;;
 			Linux)
                 trace go version
 				trace go install github.com/google/go-jsonnet/cmd/jsonnet@latest
                 ;;
 		esac
-        trace npm install --location=global openapi-merge-cli@1.3.1
+        trace npm install -g openapi-merge-cli@1.3.1
         exit 0
         ;;
 

--- a/scripts/merge_specs.sh
+++ b/scripts/merge_specs.sh
@@ -38,5 +38,5 @@ case $1 in
 			--output-file $(dirname $1)/openapi-merge.json \
 			./templates/openapi-merge.jsonnet
         trace cd $(dirname $1)
-        trace openapi-merge-cli
+        trace openapi-merge-cli 2>&1 | awk '{ print $0 } /exception/ { exit 1 }'
 esac

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -12,7 +12,7 @@ case $1 in
 
     --install)
 		trace npm --version
-		trace npm install --location=global @stoplight/cli@6.0.1280
+		trace npm install -g @stoplight/cli@6.0.1280
         exit 0
         ;;
 
@@ -22,6 +22,6 @@ case $1 in
         ;;
 
     *)
-		find $1 -maxdepth 1 \( \( -type l -and -iname '*.yaml' \) -or -iname 'openapi*.json' \) -print -delete
-		trace stoplight push --directory $1 --ci-token $2
+		# find $1 -maxdepth 1 \( \( -type l -and -iname '*.yaml' \) -or -iname 'openapi*.json' \) -print -delete
+		trace stoplight push --verbose --directory $1 --ci-token $2
 esac


### PR DESCRIPTION
This PR makes several changes to the publishing to fix it:

1. Use `redocly` instead of `swagger-cli` for bundling API specs
2. Cleans up several spec files to make lint etc. checks run cleanly.
3. Changes GitHub Action to run the publishing step in sequence rather than in parallel, as it looks like Stoplight may be choking on two publishing tasks uploading to the same account in parallel.
4. I changed the publishing tokens (in GitHub Secrets) to new projects within Stoplight. The existing projects are still there, but once this merges I'll switch the new projects to replace the old projects.