### PR TITLE
re-organize tool installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 dist
 build
 .idea/
+/node_modules/
+/tools/

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@
 #
 -include .env
 
+SHELL = /bin/sh
+
 # source folders & files
 DOC_FOLDER = docs
 SPEC_FOLDER = reference
@@ -43,6 +45,8 @@ SOURCE_SPECS = ${shell find $(SPEC_FOLDER) -type f -iname '*.yaml' | fgrep -v -f
 SOURCE_SPECS_TOP_LEVEL = ${shell find $(SPEC_FOLDER) -maxdepth 1 -type f -iname '*.yaml' | sort}
 MERGED_SPEC = combined.v1.yaml
 SOURCE_ASSETS = ${shell find $(ASSET_FOLDER) -type f -iname '*.png' | sort}
+TOOLS_BIN = tools/bin
+NPM_BIN = node_modules/.bin
 
 # output folders
 BUILD_FOLDER = build
@@ -96,22 +100,55 @@ list_targets:
 
 .PHONY: clean
 clean:
-	-rm -rv $(BUILD_FOLDER)
+	-rm -rv $(BUILD_FOLDER) tools node_modules
 
 .PHONY: clobber
 clobber: clean
 
-$(BUILD_FOLDER) $(PUBLIC_FOLDER) $(PUBLIC_SPEC_FOLDER) $(PRIVATE_FOLDER) $(PRIVATE_SPEC_FOLDER) $(CODEGEN_FOLDER):
+$(BUILD_FOLDER) $(PUBLIC_FOLDER) $(PUBLIC_SPEC_FOLDER) $(PRIVATE_FOLDER) $(PRIVATE_SPEC_FOLDER) $(CODEGEN_FOLDER) $(TOOLS_BIN):
 	mkdir -p $@
 
+GO_TOOLS = \
+	$(TOOLS_BIN)/jsonnet \
+	$(TOOLS_BIN)/oapi-codegen
+
+$(TOOLS_BIN)/jsonnet: $(TOOLS_BIN)
+	GOBIN=$(shell pwd)/$(TOOLS_BIN) go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
+
+$(TOOLS_BIN)/oapi-codegen: $(TOOLS_BIN)
+	GOBIN=$(shell pwd)/$(TOOLS_BIN) go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.13.4
+
+$(NPM_BIN)/%:
+	$(MAKE) install_npm_pkgs
+
+NPM_TOOLS = \
+	$(NPM_BIN)/markdown-link-check \
+	$(NPM_BIN)/markdownlint \
+	$(NPM_BIN)/openapi-merge-cli \
+	$(NPM_BIN)/redocly \
+	$(NPM_BIN)/spectral \
+	$(NPM_BIN)/stoplight \
+	$(NPM_BIN)/swagger-cli
+
+NPM_PKG_SPECS = \
+	@apidevtools/swagger-cli@^4.0.4 \
+	@openapi-contrib/json-schema-to-openapi-schema@^2.2.5 \
+	@redocly/cli@^1.0.0-rc.3 \
+	@stoplight/cli@^6.0.1280 \
+	@stoplight/spectral-cli@^6.8.0 \
+	markdown-link-check@^3.10.3 \
+	markdownlint-cli@^0.33.0 \
+	openapi-merge-cli@1.3.1
+
+.PHONY: install_npm_pkgs
+install_npm_pkgs:
+# When using --no-save, any dependencies not included will be deleted, so one
+# has to install all the packages all at the same time. But it saves us from
+# having to muck with packages.json.
+	npm i --no-save --local $(NPM_PKG_SPECS)
+
 .PHONY: install_tools
-install_tools:
-	./scripts/check_doc.sh --install
-	./scripts/check_spec.sh --install
-	./scripts/bundle_spec.sh --install
-	./scripts/merge_specs.sh --install
-	./scripts/publish.sh --install
-	./scripts/generate_clinic.sh --install
+install_tools: $(GO_TOOLS) $(NPM_TOOLS)
 
 .PHONY: check
 check: check_tools check_files check_toc

--- a/scripts/bundle_spec.sh
+++ b/scripts/bundle_spec.sh
@@ -1,25 +1,28 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+TOOLS_BIN=$(realpath --canonicalize-existing "$SCRIPT_DIR/../tools/bin")
+NPM_BIN=$(realpath --canonicalize-existing "$SCRIPT_DIR/../node_modules/.bin")
+PATH=$TOOLS_BIN:$NPM_BIN:$PATH
 
 trace() {
-    echo + $*
-    $*
+    echo "${PS4}$*"
+    "$@"
 }
 
 case $1 in
-	-h | --help)
-		echo "usage: $(basename $0) [-h | --help] | [-i | --install] | [-c | --self-check] | {source-spec} {bundle-spec}"
-		;;
-
-    -i | --install)
-        trace npm install -g @redocly/cli@1.0.0-rc.3
-        exit 0
-        ;;
+    -h | --help)
+	echo "usage: $(basename "$0") [-h | --help] | [-c | --self-check] | {source-spec} {bundle-spec}"
+	;;
 
     -c | --self-check)
-        trace redocly --version
-        exit 0
-        ;;
+	trace redocly --version
+	;;
 
     *)
-		trace redocly bundle $1 --output $2
+	source=${1?:source-spec is required}
+	bundle=${2?:bundle-spec is required}
+	trace redocly bundle "$source" --output "$bundle"
 esac

--- a/scripts/check_doc.sh
+++ b/scripts/check_doc.sh
@@ -1,30 +1,31 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+TOOLS_BIN=$(realpath --canonicalize-existing "$SCRIPT_DIR/../tools/bin")
+NPM_BIN=$(realpath --canonicalize-existing "$SCRIPT_DIR/../node_modules/.bin")
+PATH=$TOOLS_BIN:$NPM_BIN:$PATH
 
 trace() {
-    echo + $*
-    $*
+    echo "${PS4}$*"
+    "$@"
 }
 
 case $1 in
-	-h | --help)
-		echo "usage: $(basename $0) [-h | --help] | [-i | --install] | [-c | --self-check] | {doc-filename}"
-		;;
-
-    -i | --install)
-        trace npm --version
-        trace npm install -g markdownlint-cli@0.33.0
-        trace npm install -g markdown-link-check@3.10.3
-        exit 0
-        ;;
+    -h | --help)
+	echo "usage: $(basename "$0") [-h | --help] | [-c | --self-check] | {doc-filename}"
+	;;
 
     -c | --self-check)
-        trace markdownlint --version
-        trace markdown-link-check --version
-        exit 0
-        ;;
+	trace markdownlint --version
+	trace markdown-link-check --version
+	exit 0
+	;;
 
     *)
-        trace markdownlint $1
-        trace markdown-link-check $1 --config .markdown-link-check.json
-        trace $(dirname $0)/check_ref_links.sh $1
+	doc="${1?:doc-filename is required}"
+	trace markdownlint "$doc"
+	trace markdown-link-check "${doc}" --config .markdown-link-check.json
+	trace "$(dirname "$0")/check_ref_links.sh" "$doc"
 esac

--- a/scripts/check_spec.sh
+++ b/scripts/check_spec.sh
@@ -1,32 +1,31 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+TOOLS_BIN=$(realpath --canonicalize-existing "$SCRIPT_DIR/../tools/bin")
+NPM_BIN=$(realpath --canonicalize-existing "$SCRIPT_DIR/../node_modules/.bin")
+PATH=$TOOLS_BIN:$NPM_BIN:$PATH
 
 trace() {
-    echo + $*
-    $*
+    echo "${PS4}$*"
+    "$@"
 }
 
 case $1 in
-	-h | --help)
-		echo "usage: $(basename $0) [-h | --help] | [-i | --install] | [-c | --self-check] | {spec-filename}"
-		;;
-
-    -i | --install)
-        trace npm --version
-        trace npm install -g @stoplight/spectral-cli@6.8.0
-        trace npm install -g @apidevtools/swagger-cli@4.0.4
-        trace npm install -g @redocly/cli@1.0.0-rc.3
-        exit 0
-        ;;
+    -h | --help)
+	echo "usage: $(basename "$0") [-h | --help] | [-c | --self-check] | {spec-filename}"
+	;;
 
     -c | --self-check)
-        trace spectral --version
-        trace swagger-cli --version
-        trace redocly --version
-        exit 0
-        ;;
+	trace spectral --version
+	trace swagger-cli --version
+	trace redocly --version
+	;;
 
     *)
-        trace swagger-cli validate $1
-        trace spectral lint --quiet $1
-        trace redocly lint --format=codeframe $1
+	spec=${1?:spec-filename is required}
+	trace swagger-cli validate "$spec"
+	trace spectral lint --quiet "$spec"
+	trace redocly lint --format=codeframe "$spec"
 esac

--- a/scripts/convert_json_to_openapi.sh
+++ b/scripts/convert_json_to_openapi.sh
@@ -1,30 +1,31 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+TOOLS_BIN=$(realpath --canonicalize-existing "$SCRIPT_DIR/../tools/bin")
+NPM_BIN=$(realpath --canonicalize-existing "$SCRIPT_DIR/../node_modules/.bin")
+PATH=$TOOLS_BIN:$NPM_BIN:$PATH
 
 trace() {
-    echo + $*
-    $*
+    echo "${PS4}$*"
+    "$@"
 }
 
-case $1 in
-	-h | --help)
-		echo "usage: $(basename $0) [-h | --help] | [-i | --install] | {source} {destination}"
-		;;
-
-    -i | --install)
-        trace npm --version
-        trace npm install --location=global @openapi-contrib/json-schema-to-openapi-schema@2.2.5
-        exit 0
-        ;;
+case "$1" in
+    -h | --help)
+	echo "usage: $(basename "$0") [-h | --help] | {source} {destination}"
+	;;
 
     *)
-        SOURCE=$1
-        DESTINATION=$2
-        find $SOURCE -depth -name "*.json" -print0 | while read -d $'\0' file
-        do
-            dst=${file%".json"}.yaml
-            dst="$DESTINATION"${dst#"$SOURCE"}
-            mkdir -p $(dirname $dst)
-            echo converting $file
-            json-schema-to-openapi-schema convert $file | yq -P > $dst
-        done
+	SOURCE=${1?:source is required}
+	DESTINATION=${2?:destination is required}
+	find "$SOURCE" -depth -name "*.json" -print0 | while read -d $'\0' file
+	do
+	    dst=${file%".json"}.yaml
+	    dst="$DESTINATION"${dst#"$SOURCE"}
+	    mkdir -p "$(dirname "$dst")"
+	    echo "converting $file"
+	    json-schema-to-openapi-schema convert "$file" | yq -P > "$dst"
+	done
 esac

--- a/scripts/generate_clinic.sh
+++ b/scripts/generate_clinic.sh
@@ -1,40 +1,38 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+TOOLS_BIN=$(realpath --canonicalize-existing "$SCRIPT_DIR/../tools/bin")
+NPM_BIN=$(realpath --canonicalize-existing "$SCRIPT_DIR/../node_modules/.bin")
+PATH=$TOOLS_BIN:$NPM_BIN:$PATH
 
 trace() {
-    echo + $*
-    $*
+    echo "${PS4}$*"
+    "$@"
 }
 
 case $1 in
-	-h | --help)
-		echo "usage: $(basename $0) [-h | --help] | [-i | --install] | [-c | --self-check] | {source-spec-filename} {bundled-spec-filename}"
-		;;
-
-    -i | --install)
-		trace npm --version
-		trace npm install -g @apidevtools/swagger-cli@4.0.4
-		trace go version
-		trace go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@latest
-        exit 0
-        ;;
+    -h | --help)
+	echo "usage: $(basename "$0") [-h | --help] | [-c | --self-check] | {source-spec-filename} {bundled-spec-filename}"
+	;;
 
     -c | --self-check)
-        trace swagger-cli --version
-        trace oapi-codegen --version
-        exit 0
-        ;;
+	trace swagger-cli --version
+	trace oapi-codegen --version
+	;;
 
     *)
-        source=$1
-		bundled=$2
-        server=$(dirname $bundled)/server
-        client=$(dirname $bundled)/client
-        common="--old-config-style --exclude-tags=Confirmations --package=api"
-		trace swagger-cli bundle $source -o $bundled -t yaml
-        trace mkdir -p $server $client
-		trace oapi-codegen $common --generate=server -o $server/gen_server.go $bundled
-		trace oapi-codegen $common --generate=spec -o $server/gen_spec.go $bundled
-		trace oapi-codegen $common --generate=types -o $server/gen_types.go $bundled
-        trace oapi-codegen $common --generate=types -o $client/types.go $bundled
-	    trace oapi-codegen $common --generate=client -o $client/client.go $bundled
+	source=${1?:source-spec-filename is required}
+	bundled=${2?:bundled-spec-filename is required}
+	server="$(dirname "$bundled")/server"
+	client="$(dirname "$bundled")/client"
+	common=( --old-config-style --exclude-tags=Confirmations --package=api )
+	trace swagger-cli bundle "$source" -o "$bundled" -t yaml
+	trace mkdir -p "$server" "$client"
+	trace oapi-codegen "${common[@]}" --generate=server -o "$server/gen_server.go" "$bundled"
+	trace oapi-codegen "${common[@]}" --generate=spec -o "$server/gen_spec.go" "$bundled"
+	trace oapi-codegen "${common[@]}" --generate=types -o "$server/gen_types.go" "$bundled"
+	trace oapi-codegen "${common[@]}" --generate=types -o "$client/types.go" "$bundled"
+	trace oapi-codegen "${common[@]}" --generate=client -o "$client/client.go" "$bundled"
 esac

--- a/scripts/merge_specs.sh
+++ b/scripts/merge_specs.sh
@@ -1,42 +1,35 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+TOOLS_BIN=$(realpath --canonicalize-existing "$SCRIPT_DIR/../tools/bin")
+NPM_BIN=$(realpath --canonicalize-existing "$SCRIPT_DIR/../node_modules/.bin")
+PATH=$TOOLS_BIN:$NPM_BIN:$PATH
 
 trace() {
-    echo + $*
-    $*
+    echo "${PS4}$*"
+    "$@"
 }
 
 case $1 in
-	-h | --help)
-		echo "usage: $(basename $0) [-h | --help] | [-i | --install] | [-c | --self-check] | {merged-spec-filename}"
-		;;
-
-    -i | --install)
-		case $(uname -s) in
-			Darwin)
-                trace brew --version
-        		trace brew install jsonnet
-                ;;
-			Linux)
-                trace go version
-				trace go install github.com/google/go-jsonnet/cmd/jsonnet@latest
-                ;;
-		esac
-        trace npm install -g openapi-merge-cli@1.3.1
-        exit 0
-        ;;
+    -h | --help)
+	echo "usage: $(basename "$0") [-h | --help] | [-c | --self-check] | {merged-spec-filename}"
+	;;
 
     -c | --self-check)
-        trace jsonnet --version
-        trace openapi-merge-cli --version
-        exit 0
-        ;;
+	trace jsonnet --version
+	trace openapi-merge-cli --version
+	;;
 
     *)
-		trace jsonnet --ext-str excludeTags="$2" \
-			--ext-str sourceFolder=./ \
-			--ext-str outputFile=$(basename $1) \
-			--output-file $(dirname $1)/openapi-merge.json \
-			./templates/openapi-merge.jsonnet
-        trace cd $(dirname $1)
-        trace openapi-merge-cli 2>&1 | awk '{ print $0 } /exception/ { exit 1 }'
+	spec=${1?:merged-spec-filename is required}
+	excluded=${2:-}
+	trace jsonnet --ext-str excludeTags="$excluded" \
+	      --ext-str sourceFolder=./ \
+	      --ext-str outputFile="$(basename "$spec")" \
+	      --output-file "$(dirname "$spec")/openapi-merge.json" \
+	      ./templates/openapi-merge.jsonnet
+	trace cd "$(dirname "$spec")"
+	trace openapi-merge-cli 2>&1 | awk '{ print $0 } /exception/ { exit 1 }'
 esac

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,27 +1,30 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+TOOLS_BIN=$(realpath --canonicalize-existing "$SCRIPT_DIR/../tools/bin")
+NPM_BIN=$(realpath --canonicalize-existing "$SCRIPT_DIR/../node_modules/.bin")
+PATH=$TOOLS_BIN:$NPM_BIN:$PATH
 
 trace() {
-    echo + $*
-    $*
+    echo "${PS4}$*"
+    "$@"
 }
 
 case $1 in
-	--help)
-		echo "usage: $(basename $0) [-h | --help] | [-i | --install] | [-c | --self-check] | {folder} {token}"
-		;;
-
-    --install)
-		trace npm --version
-		trace npm install -g @stoplight/cli@6.0.1280
-        exit 0
-        ;;
+    --help)
+	echo "usage: $(basename "$0") [-h | --help] | [-i | --install] | [-c | --self-check] | {directory} {token}"
+	;;
 
     --self-check)
-        trace stoplight --version
-        exit 0
-        ;;
+	trace stoplight --version
+	exit 0
+	;;
 
     *)
-		# find $1 -maxdepth 1 \( \( -type l -and -iname '*.yaml' \) -or -iname 'openapi*.json' \) -print -delete
-		trace stoplight push --verbose --directory $1 --ci-token $2
+	dir=${1?:directory is required}
+	token=${2?:token is required}
+	# find $1 -maxdepth 1 \( \( -type l -and -iname '*.yaml' \) -or -iname 'openapi*.json' \) -print -delete
+	trace stoplight push --verbose --directory "$dir" --ci-token "$token"
 esac


### PR DESCRIPTION
_This PR is very much take it or leave it, just some easy tweaks I saw that I thought might be an improvement._

Before this change, tools were installed on the user's system, outside of the project directory, some into `npm --global prefix`, others in `GOPATH`. This can be annoying, as it can overwrite existing tools, or different projects with requirements on different versions of tools can conflict.

The tools have been re-organized, so that they're all installed by the Makefile, and placed within the project directory. Specifically, go binaries are in tools/bin, and node scripts are in node_modules/.bin. The scripts have been edited to modify their paths to prefer the use of these project-specified tools, so that conflicts with other user-installed tools should be prevented.

I also spent a little time doing some shell script cleanup, little things like quoting arguments, checking for required arguments and the like.

Oh, and I versioned the go tools that were being installed. No one like having those @latest surprises on a production deployment!