### PR TITLE
adds device token endpoint

### DIFF
--- a/reference/auth.v1.yaml
+++ b/reference/auth.v1.yaml
@@ -722,6 +722,28 @@ paths:
       security:
         - serverToken: []
 
+  '/auth/v1/users/{userId}/device_tokens':
+    parameters:
+      - $ref: './common/parameters/tidepooluserid.yaml'
+    post:
+      operationId: CreateDeviceTokenForUser
+      summary: Post Device Token
+      description: >-
+        Stores a token used to send notifications to a device such as a mobile phone.
+      requestBody:
+        $ref: '#/components/requestBodies/DeviceToken'
+      responses:
+        '200':
+          description: 200 OK
+        '400':
+          $ref: './common/responses/badrequest.v1.yaml'
+        '403':
+          $ref: './common/responses/forbidden.v1.yaml'
+      security:
+        - sessionToken: []
+      tags:
+        - Internal
+
 components:
   securitySchemes:
     basicAuth:
@@ -784,6 +806,14 @@ components:
         'application/json':
           schema:
             $ref: './auth/models/providers/updatesession.v1.yaml'
+
+    DeviceToken:
+      description: 'Device token used for sending push notifications to a mobile device.'
+      content:
+        'application/json':
+          schema:
+            oneOf:
+              - $ref: './auth/models/devicetoken-apple.v1.yaml'
 
   responses:
     User:

--- a/reference/auth/models/devicetoken-apple.v1.yaml
+++ b/reference/auth/models/devicetoken-apple.v1.yaml
@@ -1,0 +1,20 @@
+title: Apple Device Token
+description: >-
+  An opaque token used to send push notifications to an Apple-branded device.
+type: object
+required:
+  - token
+  - environment
+properties:
+  token:
+    description: >-
+      Base64-encoded opaque blob of data, as received from Apple.
+    type: string
+    maxLength: 8192
+  environment:
+    description: >-
+      The Apple-defined environment determines which server URLs to communicate with.
+    type: string
+    enum:
+      - production
+      - sandbox


### PR DESCRIPTION
This endpoint is for pushing a device token that can be used later to send push notifications to the device.

BACK-2506

This will be a draft until https://github.com/tidepool-org/platform/pull/667 is approved.