### PR TITLE
[BACK-2773/3474/3475] Updates to data model for twiist integration

### DIFF
--- a/docs/device-data/data-types/device-event/pump-settings-override.md
+++ b/docs/device-data/data-types/device-event/pump-settings-override.md
@@ -67,13 +67,13 @@ The method indicates how the preset was enabled, if known. It can be one of `aut
 
 ## Duration (`duration`)
 
-The `duration` the override is enabled for. When the override is first enabled the `duration` field can indicate how long the override is expected to be enabled for. Once the override is disabled the `duration` field should be updated to indicate the actual duration is was enable for. In this case, if the duration is less than what was expected, the `expectedDuration` field should be specified. If the override is enable indefinitely (meaning that there is no **planned** time to disable) then the `duration` field should not be specified until after the override is disabled.
+The `duration` the override is enabled for. When the override is first enabled the `duration` field can indicate how long the override is expected to be enabled for. Once the override is disabled the `duration` field should be updated to indicate the actual duration is was enable for. In this case, if the duration is less than what was expected, the `expectedDuration` field should be specified. If the override is enable indefinitely (meaning that there is no **planned** time to disable) then the `duration` field should not be specified until after the override is disabled. The `duration` is milliseconds.
 
 ---
 
 ## Expected Duration (`expectedDuration`)
 
-Once the override is disabled, if the actual duration is less than the initial expected duration, then the `expectedDuration` field should be specified and the `duration` field updated to the actual duration.
+Once the override is disabled, if the actual duration is less than the initial expected duration, then the `expectedDuration` field should be specified and the `duration` field updated to the actual duration. The `expectedDuration` is milliseconds.
 
 ---
 
@@ -110,8 +110,8 @@ The insulin sensitivity scale factor in effect while the override is enabled. Th
   "overrideType": "preset",
   "overridePreset": "Running",
   "method": "manual",
-  "duration": 2700,
-  "expectedDuration": 7200,
+  "duration": 2700000,
+  "expectedDuration": 7200000,
   "bgTarget": {
     "high": 160,
     "low": 150

--- a/docs/device-data/data-types/pump-settings.md
+++ b/docs/device-data/data-types/pump-settings.md
@@ -200,7 +200,7 @@ An abbreviation for the preset. Commonly set to an emoji.
 <!-- omit in toc -->
 ### Duration (`duration`)
 
-The intended duration of the override when initially enabled. Not specifying this field indicates that the override should be enable indefinitely.
+The intended duration of the override when initially enabled. Not specifying this field indicates that the override should be enable indefinitely. The `duration` is milliseconds.
 
 <!-- omit in toc -->
 ### Blood Glucose Target (Preset) (`bgTarget`)
@@ -340,7 +340,7 @@ The blood glucose value may be mg/dL or mmol/L, but Platform will convert all bl
     "overridePresets": {
         "Running": {
             "abbreviation": "🏃‍♀️",
-            "duration": 7200,
+            "duration": 7200000,
             "bgTarget": {},
             "basalRateScaleFactor": 0.8,
             "carbRatioScaleFactor": 1.25,
@@ -459,7 +459,7 @@ The blood glucose value may be mg/dL or mmol/L, but Platform will convert all bl
     "overridePresets": {
         "Running": {
             "abbreviation": "🏃‍♀️",
-            "duration": 7200,
+            "duration": 7200000,
             "bgTarget": {},
             "basalRateScaleFactor": 0.8,
             "carbRatioScaleFactor": 1.25,
@@ -579,7 +579,7 @@ The blood glucose value may be mg/dL or mmol/L, but Platform will convert all bl
     "overridePresets": {
         "Running": {
             "abbreviation": "🏃‍♀️",
-            "duration": 7200,
+            "duration": 7200000,
             "bgTarget": {},
             "basalRateScaleFactor": 0.8,
             "carbRatioScaleFactor": 1.25,

--- a/reference/data/models/bolus/deliverycontext.v1.yaml
+++ b/reference/data/models/bolus/deliverycontext.v1.yaml
@@ -1,8 +1,10 @@
 title: Bolus Delivery Context
 type: string
 enum:
-  - device
   - algorithm
+  - device
+  - oneButton
   - remote
+  - watch
   - undetermined
   

--- a/reference/data/models/bolus/deliverycontext.v1.yaml
+++ b/reference/data/models/bolus/deliverycontext.v1.yaml
@@ -7,4 +7,3 @@ enum:
   - remote
   - watch
   - undetermined
-  

--- a/reference/data/models/deviceevent/pumpsettingsoverride.v1.yaml
+++ b/reference/data/models/deviceevent/pumpsettingsoverride.v1.yaml
@@ -32,14 +32,14 @@ allOf:
         type: number
         format: float
         minimum: 0
-        maximum: 604800
-        example: 2700
+        maximum: 604800000
+        example: 2700000
       expectedDuration:
         type: number
         format: float
         minimum: 0
-        maximum: 604800
-        example: 7200
+        maximum: 604800000
+        example: 7200000
       bgTarget:
         $ref: ../blood/glucose/target.v1.yaml
         example:

--- a/reference/data/models/pumpsettings/overridepreset.v1.yaml
+++ b/reference/data/models/pumpsettings/overridepreset.v1.yaml
@@ -12,7 +12,7 @@ allOf:
         type: number
         format: float
         minimum: 0
-        maximum: 604800
+        maximum: 604800000
         example: 7200
       bgTarget:
         $ref: ../blood/glucose/target.v1.yaml


### PR DESCRIPTION
- Update pumpSettingsOverride duration and expectedDuration to milliseconds
- Update pumpSettings.presetOverrides duration to milliseconds
- Add bolus.deliveryContext values oneButton and watch
- https://tidepool.atlassian.net/browse/BACK-2773
- https://tidepool.atlassian.net/browse/BACK-3474
- https://tidepool.atlassian.net/browse/BACK-3475