### PR TITLE
migrate placeholer dataSources to providerConnectionRequests

### DIFF
--- a/reference/clinic/models/dataSource.v1.yaml
+++ b/reference/clinic/models/dataSource.v1.yaml
@@ -5,8 +5,6 @@ properties:
     type: string
     title: Data source connection state
     enum:
-      - pending
-      - pendingReconnect
       - connected
       - disconnected
       - error

--- a/reference/clinic/models/dataSource.v1.yaml
+++ b/reference/clinic/models/dataSource.v1.yaml
@@ -25,8 +25,6 @@ properties:
     $ref: ../../common/models/datetime.v1.yaml
   modifiedTime:
     $ref: ../../common/models/datetime.v1.yaml
-  expirationTime:
-    $ref: ../../common/models/datetime.v1.yaml
   latestDataTime:
     $ref: ../../common/models/datetime.v1.yaml
     title: Time of the latest data point from this source

--- a/reference/clinic/models/patient.v1.yaml
+++ b/reference/clinic/models/patient.v1.yaml
@@ -40,6 +40,7 @@ properties:
     nullable: true
     items:
       $ref: ./dataSource.v1.yaml
+    readOnly: true
   lastUploadReminderTime:
     type: string
     format: date-time

--- a/reference/clinic/models/providerConnectionRequest.v1.yaml
+++ b/reference/clinic/models/providerConnectionRequest.v1.yaml
@@ -12,6 +12,12 @@ properties:
     $ref: ./providerId.v1.yaml
     x-stoplight:
       id: ej94kmuykpg1k
+  expirationTime:
+    type: string
+    format: date-time
+    x-go-type-skip-optional-pointer: true
+    x-omitzero: true
+    readOnly: true
 required:
   - createdTime
   - providerName


### PR DESCRIPTION
The expirationTime property of dataSources is moved to providerConnectionRequests. The dataSource states of pending and pendingReconnect are no longer valid. They can instead be identified like so:

- pending: a (non-expired) providerConnectionRequest exists for provider X, but no dataSource for that provider exists.

- pendingReconnect: a (non-expired) providerConnectionRequest exists for provider X, and there's also a dataSource for that provider, whose state isn't "connected".

BACK-4414