### PR TITLE
device issues dashboard

### DIFF
--- a/reference/clinic.v1.yaml
+++ b/reference/clinic.v1.yaml
@@ -969,6 +969,27 @@ paths:
           in: query
           # Skipping the pointer here ran afoul of https://github.com/oapi-codegen/oapi-codegen/issues/1263
           # x-go-type-skip-optional-pointer: true
+        - name: deviceIssues
+          description: |
+            Includes patients experiencing one or more of the device issues specified.
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - disconnected
+                - erroring
+                - expiredConnectionInvitation
+                - staleConnectionInvitation
+                - staleData
+          in: query
+          style: form
+          explode: false
+        - name: omitHiddenDeviceIssues
+          description: Exclude any devices issues marked as hidden.
+          schema:
+            type: boolean
+          in: query
 
       description: Retrieve a list of patients of a clinic
     post:
@@ -2326,6 +2347,17 @@ paths:
         - Clinics
         - Internal
       description: Send a new request to the patient to connect a data provider
+  '/v1/device_issues':
+    post:
+      summary: Update device issues
+      description: Endpoint used to trigger an update of each patients' device issues.
+      operationId: UpdateDeviceIssues
+      responses:
+        '200':
+          description: OK
+      tags:
+        - Clinics
+        - Internal
 components:
   schemas:
     clinics.v1:

--- a/reference/clinic/models/deviceIssue.v1.yaml
+++ b/reference/clinic/models/deviceIssue.v1.yaml
@@ -1,0 +1,17 @@
+type: object
+properties:
+  effectiveTime:
+    $ref: ../../common/models/datetime.v1.yaml
+  providerId:
+    $ref: ./providerId.v1.yaml
+  hidden:
+    $ref: '../../common/models/datetime.v1.yaml'
+    description: |
+      Set this value to indicate that clinicians no longer wish to see
+      this issue in their device issues dashboard.
+required:
+  - effectiveTime
+  - providerId
+x-go-type-skip-optional-pointer: true
+x-omitzero: true
+x-omitempty: true

--- a/reference/clinic/models/deviceIssues.v1.yaml
+++ b/reference/clinic/models/deviceIssues.v1.yaml
@@ -1,0 +1,12 @@
+type: object
+properties:
+  disconnected:
+    $ref: ./deviceIssue.v1.yaml
+  erroring:
+    $ref: ./deviceIssue.v1.yaml
+  expiredConnectionInvitation:
+    $ref: ./deviceIssue.v1.yaml
+  staleConnectionInvitation:
+    $ref: ./deviceIssue.v1.yaml
+  staleData:
+    $ref: ./deviceIssue.v1.yaml

--- a/reference/clinic/models/patient.v1.yaml
+++ b/reference/clinic/models/patient.v1.yaml
@@ -71,6 +71,14 @@ properties:
     $ref: ./glycemicRanges.v1.yaml
   diagnosisType:
     $ref: ../../metadata/models/diagnosisType.v1.yaml
+  deviceIssues:
+    $ref: ./deviceIssues.v1.yaml
+  primaryDeviceProviderName:
+    $ref: ./providerId.v1.yaml
+    description: The device used in various dashboards, e.g. TIDE or Device Issues Dashboard.
+    nullable: true
+    x-go-type-skip-optional-pointer: true
+    readOnly: true
 required:
   - id
   - fullName


### PR DESCRIPTION
These issues are displayed on a new dashboard for clinicians. Each device issue can be hidden by setting the "hidden" attribute on the issue. The issues pertain to the active device, which is now set on a per patient basis.

BACK-4319
BACK-4382