### PR TITLE
devices API docs

### DIFF
--- a/reference/devices.v1.yaml
+++ b/reference/devices.v1.yaml
@@ -1,0 +1,151 @@
+openapi: 3.0.0
+info:
+  title: Devices API
+  version: '1.0'
+  description: |-
+    The Tidepool API is an HTTP REST API used by Tidepool clients use to communicate with the Tidepool Platform.
+
+    For more information, see the [Getting Started](../docs/quick-start.md) section.
+  termsOfService: https://developer.tidepool.org/terms-of-use
+  contact:
+    name: Tidepool
+    url: 'https://www.tidepool.org/'
+    email: support@tidepool.org
+  license:
+    name: BSD-2-Clause
+    url: 'https://github.com/tidepool-org/devices/blob/master/LICENSE'
+  x-tidepool-service: https://github.com/tidepool-org/devices
+
+servers:
+  - url: 'https://external.integration.tidepool.org'
+    description: integration
+  - url: 'https://api.tidepool.org'
+    description: production
+  - url: 'https://dev1.dev.tidepool.org'
+    description: dev1
+  - url: 'https://qa1.development.tidepool.org'
+    description: qa1
+  - url: 'https://qa2.development.tidepool.org'
+    description: qa2
+
+# No authentication is required to access the Devices API
+security: []
+
+tags:
+  - name: Devices
+    description: >-
+      List and retrieve information about Tidepool supported devices,
+      such as insulin pumps and continuous glucose monitors (CGMs),
+      including the guard rails used to validate device settings.
+
+paths:
+  '/v1/devices/pumps':
+    get:
+      operationId: ListPumps
+      summary: List Pumps
+      description: >-
+        List all Tidepool supported insulin pumps.
+      responses:
+        '200':
+          $ref: '#/components/responses/PumpList'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Devices
+
+  '/v1/devices/pumps/{id}':
+    parameters:
+      - $ref: './devices/parameters/deviceid.v1.yaml'
+    get:
+      operationId: GetPumpById
+      summary: Get Pump by ID
+      description: >-
+        Get a Tidepool supported insulin pump by its unique device identifier.
+      responses:
+        '200':
+          $ref: '#/components/responses/Pump'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Devices
+
+  '/v1/devices/cgms':
+    get:
+      operationId: ListCgms
+      summary: List CGMs
+      description: >-
+        List all Tidepool supported continuous glucose monitors (CGMs).
+      responses:
+        '200':
+          $ref: '#/components/responses/CgmList'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Devices
+
+  '/v1/devices/cgms/{id}':
+    parameters:
+      - $ref: './devices/parameters/deviceid.v1.yaml'
+    get:
+      operationId: GetCgmById
+      summary: Get CGM by ID
+      description: >-
+        Get a Tidepool supported continuous glucose monitor (CGM) by its unique device identifier.
+      responses:
+        '200':
+          $ref: '#/components/responses/Cgm'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Devices
+
+components:
+  responses:
+    NotFound:
+      description: Not Found
+      content:
+        'application/json':
+          schema:
+            $ref: './devices/models/error.v1.yaml'
+    ServerError:
+      description: Internal Server Error
+      content:
+        'application/json':
+          schema:
+            $ref: './devices/models/error.v1.yaml'
+    Pump:
+      description: Insulin pump
+      content:
+        'application/json':
+          schema:
+            title: Get Pump by ID Response
+            type: object
+            properties:
+              pump:
+                $ref: './devices/models/pump.v1.yaml'
+    PumpList:
+      description: List of insulin pumps
+      content:
+        'application/json':
+          schema:
+            $ref: './devices/models/pumplist.v1.yaml'
+    Cgm:
+      description: Continuous glucose monitor
+      content:
+        'application/json':
+          schema:
+            title: Get CGM by ID Response
+            type: object
+            properties:
+              cgm:
+                $ref: './devices/models/cgm.v1.yaml'
+    CgmList:
+      description: List of continuous glucose monitors
+      content:
+        'application/json':
+          schema:
+            $ref: './devices/models/cgmlist.v1.yaml'

--- a/reference/devices/models/absolutebounds.v1.yaml
+++ b/reference/devices/models/absolutebounds.v1.yaml
@@ -1,0 +1,11 @@
+title: Absolute Bounds
+description: >-
+  Device specific closed range of allowed values
+type: object
+properties:
+  minimum:
+    $ref: './fixeddecimal.v1.yaml'
+  maximum:
+    $ref: './fixeddecimal.v1.yaml'
+  increment:
+    $ref: './fixeddecimal.v1.yaml'

--- a/reference/devices/models/basalratemaximumguardrail.v1.yaml
+++ b/reference/devices/models/basalratemaximumguardrail.v1.yaml
@@ -1,0 +1,16 @@
+title: Basal Rate Maximum Guard Rail
+description: >-
+  Guard rail for the maximum basal rate setting
+type: object
+properties:
+  units:
+    $ref: './basalrateunits.v1.yaml'
+  defaultValue:
+    description: >-
+      Default value. May be `null` if the device has no default value for the setting.
+    type: object
+    nullable: true
+    allOf:
+      - $ref: './fixeddecimal.v1.yaml'
+  absoluteBounds:
+    $ref: './absolutebounds.v1.yaml'

--- a/reference/devices/models/basalratesguardrail.v1.yaml
+++ b/reference/devices/models/basalratesguardrail.v1.yaml
@@ -1,0 +1,22 @@
+title: Basal Rates Guard Rail
+description: >-
+  Guard rail for the basal rate schedule setting
+type: object
+properties:
+  units:
+    $ref: './basalrateunits.v1.yaml'
+  defaultValue:
+    description: >-
+      Default value. May be `null` if the device has no default value for the setting.
+    type: object
+    nullable: true
+    allOf:
+      - $ref: './fixeddecimal.v1.yaml'
+  absoluteBounds:
+    description: >-
+      Device specific absolute bounds. Some pumps might have different increments for different ranges.
+    type: array
+    items:
+      $ref: './absolutebounds.v1.yaml'
+  maxSegments:
+    $ref: './maxsegments.v1.yaml'

--- a/reference/devices/models/basalrateunits.v1.yaml
+++ b/reference/devices/models/basalrateunits.v1.yaml
@@ -1,0 +1,7 @@
+title: Basal Rate Units
+description: >-
+  Basal rate units
+type: string
+enum:
+  - UnitsPerHour
+default: UnitsPerHour

--- a/reference/devices/models/bloodglucoseunits.v1.yaml
+++ b/reference/devices/models/bloodglucoseunits.v1.yaml
@@ -1,0 +1,7 @@
+title: Blood Glucose Units
+description: >-
+  Blood glucose units
+type: string
+enum:
+  - MilligramsPerDeciliter
+default: MilligramsPerDeciliter

--- a/reference/devices/models/bolusamountmaximumguardrail.v1.yaml
+++ b/reference/devices/models/bolusamountmaximumguardrail.v1.yaml
@@ -1,0 +1,11 @@
+title: Bolus Amount Maximum Guard Rail
+description: >-
+  Guard rail for the maximum bolus amount setting
+type: object
+properties:
+  units:
+    $ref: './bolusunits.v1.yaml'
+  recommendedBounds:
+    $ref: './recommendedbounds.v1.yaml'
+  absoluteBounds:
+    $ref: './absolutebounds.v1.yaml'

--- a/reference/devices/models/bolusunits.v1.yaml
+++ b/reference/devices/models/bolusunits.v1.yaml
@@ -1,0 +1,7 @@
+title: Bolus Units
+description: >-
+  Bolus amount units
+type: string
+enum:
+  - Units
+default: Units

--- a/reference/devices/models/carbohydrateratioguardrail.v1.yaml
+++ b/reference/devices/models/carbohydrateratioguardrail.v1.yaml
@@ -1,0 +1,13 @@
+title: Carbohydrate Ratio Guard Rail
+description: >-
+  Guard rail for the carbohydrate ratio setting
+type: object
+properties:
+  units:
+    $ref: './carbohydrateratiounits.v1.yaml'
+  recommendedBounds:
+    $ref: './recommendedbounds.v1.yaml'
+  absoluteBounds:
+    $ref: './absolutebounds.v1.yaml'
+  maxSegments:
+    $ref: './maxsegments.v1.yaml'

--- a/reference/devices/models/carbohydrateratiounits.v1.yaml
+++ b/reference/devices/models/carbohydrateratiounits.v1.yaml
@@ -1,0 +1,7 @@
+title: Carbohydrate Ratio Units
+description: >-
+  Carbohydrate ratio units
+type: string
+enum:
+  - GramsPerUnit
+default: GramsPerUnit

--- a/reference/devices/models/cgm.v1.yaml
+++ b/reference/devices/models/cgm.v1.yaml
@@ -1,0 +1,25 @@
+title: CGM
+description: >-
+  A Tidepool supported continuous glucose monitor
+type: object
+properties:
+  id:
+    $ref: '../../common/models/guid.v1.yaml'
+  displayName:
+    description: >-
+      Device display name
+    type: string
+    example: Dexcom G6
+  manufacturers:
+    description: >-
+      Device manufacturers
+    type: array
+    items:
+      type: string
+    example:
+      - Dexcom
+  model:
+    description: >-
+      Device model
+    type: string
+    example: G6

--- a/reference/devices/models/cgmlist.v1.yaml
+++ b/reference/devices/models/cgmlist.v1.yaml
@@ -1,0 +1,9 @@
+title: List CGMs Response
+description: >-
+  List of Tidepool supported continuous glucose monitors
+type: object
+properties:
+  cgms:
+    type: array
+    items:
+      $ref: './cgm.v1.yaml'

--- a/reference/devices/models/correctionrangeguardrail.v1.yaml
+++ b/reference/devices/models/correctionrangeguardrail.v1.yaml
@@ -1,0 +1,13 @@
+title: Correction Range Guard Rail
+description: >-
+  Guard rail for a correction range setting
+type: object
+properties:
+  units:
+    $ref: './bloodglucoseunits.v1.yaml'
+  recommendedBounds:
+    $ref: './recommendedbounds.v1.yaml'
+  absoluteBounds:
+    $ref: './absolutebounds.v1.yaml'
+  maxSegments:
+    $ref: './maxsegments.v1.yaml'

--- a/reference/devices/models/error.v1.yaml
+++ b/reference/devices/models/error.v1.yaml
@@ -1,0 +1,25 @@
+title: Devices Error
+description: >-
+  Error returned by the Devices API, in the gRPC-Gateway error format.
+type: object
+properties:
+  code:
+    description: >-
+      [gRPC status code](https://grpc.io/docs/guides/status-codes/) (e.g. `5` for `NOT_FOUND`)
+    type: integer
+    format: int32
+    example: 5
+  message:
+    description: >-
+      Human readable error message
+    type: string
+    example: pump not found
+  details:
+    description: >-
+      Additional error details
+    type: array
+    items:
+      type: object
+required:
+  - code
+  - message

--- a/reference/devices/models/fixeddecimal.v1.yaml
+++ b/reference/devices/models/fixeddecimal.v1.yaml
@@ -1,0 +1,18 @@
+title: Fixed Decimal
+description: >-
+  A fixed precision decimal number, expressed as whole units and nano (10^-9) units.
+  For example, the value 5.75 is represented as `units` = 5 and `nanos` = 750000000.
+type: object
+properties:
+  units:
+    description: >-
+      The whole units of the amount
+    type: integer
+    format: int32
+    example: 5
+  nanos:
+    description: >-
+      Number of nano (10^-9) units of the amount
+    type: integer
+    format: int32
+    example: 750000000

--- a/reference/devices/models/glucosesafetylimitguardrail.v1.yaml
+++ b/reference/devices/models/glucosesafetylimitguardrail.v1.yaml
@@ -1,0 +1,11 @@
+title: Glucose Safety Limit Guard Rail
+description: >-
+  Guard rail for the glucose safety limit setting
+type: object
+properties:
+  units:
+    $ref: './bloodglucoseunits.v1.yaml'
+  recommendedBounds:
+    $ref: './recommendedbounds.v1.yaml'
+  absoluteBounds:
+    $ref: './absolutebounds.v1.yaml'

--- a/reference/devices/models/guardrails.v1.yaml
+++ b/reference/devices/models/guardrails.v1.yaml
@@ -1,0 +1,23 @@
+title: Guard Rails
+description: >-
+  Guard rails used to validate therapy settings for the device
+type: object
+properties:
+  glucoseSafetyLimit:
+    $ref: './glucosesafetylimitguardrail.v1.yaml'
+  insulinSensitivity:
+    $ref: './insulinsensitivityguardrail.v1.yaml'
+  basalRates:
+    $ref: './basalratesguardrail.v1.yaml'
+  carbohydrateRatio:
+    $ref: './carbohydrateratioguardrail.v1.yaml'
+  basalRateMaximum:
+    $ref: './basalratemaximumguardrail.v1.yaml'
+  bolusAmountMaximum:
+    $ref: './bolusamountmaximumguardrail.v1.yaml'
+  correctionRange:
+    $ref: './correctionrangeguardrail.v1.yaml'
+  preprandialCorrectionRange:
+    $ref: './correctionrangeguardrail.v1.yaml'
+  workoutCorrectionRange:
+    $ref: './correctionrangeguardrail.v1.yaml'

--- a/reference/devices/models/insulinsensitivityguardrail.v1.yaml
+++ b/reference/devices/models/insulinsensitivityguardrail.v1.yaml
@@ -1,0 +1,13 @@
+title: Insulin Sensitivity Guard Rail
+description: >-
+  Guard rail for the insulin sensitivity setting
+type: object
+properties:
+  units:
+    $ref: './bloodglucoseunits.v1.yaml'
+  recommendedBounds:
+    $ref: './recommendedbounds.v1.yaml'
+  absoluteBounds:
+    $ref: './absolutebounds.v1.yaml'
+  maxSegments:
+    $ref: './maxsegments.v1.yaml'

--- a/reference/devices/models/maxsegments.v1.yaml
+++ b/reference/devices/models/maxsegments.v1.yaml
@@ -1,0 +1,6 @@
+title: Maximum Segments
+description: >-
+  Maximum number of time segments
+type: integer
+format: int32
+example: 48

--- a/reference/devices/models/pump.v1.yaml
+++ b/reference/devices/models/pump.v1.yaml
@@ -1,0 +1,27 @@
+title: Pump
+description: >-
+  A Tidepool supported insulin pump
+type: object
+properties:
+  id:
+    $ref: '../../common/models/guid.v1.yaml'
+  displayName:
+    description: >-
+      Device display name
+    type: string
+    example: Omnipod 5
+  manufacturers:
+    description: >-
+      Device manufacturers
+    type: array
+    items:
+      type: string
+    example:
+      - Insulet
+  model:
+    description: >-
+      Device model
+    type: string
+    example: Omnipod 5
+  guardRails:
+    $ref: './guardrails.v1.yaml'

--- a/reference/devices/models/pumplist.v1.yaml
+++ b/reference/devices/models/pumplist.v1.yaml
@@ -1,0 +1,9 @@
+title: List Pumps Response
+description: >-
+  List of Tidepool supported insulin pumps
+type: object
+properties:
+  pumps:
+    type: array
+    items:
+      $ref: './pump.v1.yaml'

--- a/reference/devices/models/recommendedbounds.v1.yaml
+++ b/reference/devices/models/recommendedbounds.v1.yaml
@@ -1,0 +1,11 @@
+title: Recommended Bounds
+description: >-
+  Tidepool recommended closed range of values.
+  May be `null` if there are no recommended bounds for the setting.
+type: object
+nullable: true
+properties:
+  minimum:
+    $ref: './fixeddecimal.v1.yaml'
+  maximum:
+    $ref: './fixeddecimal.v1.yaml'

--- a/reference/devices/parameters/deviceid.v1.yaml
+++ b/reference/devices/parameters/deviceid.v1.yaml
@@ -1,0 +1,7 @@
+description: >-
+  Device ID
+name: id
+in: path
+required: true
+schema:
+  $ref: '../../common/models/guid.v1.yaml'


### PR DESCRIPTION
These docs where generated by Claude. Currently this service is
undocumented. While these might not be 100% accurate, they're at least
a good starting place from which refine them.

I had claude generate the docs from the api.proto file, then refined
it by having it test the docs against my local devices service, and
followed that up by having it look for models and parameters it could
reuse from the references/common directory.
