### PR TITLE
make tags optional in TIDE reports (and some cleanup)

### DIFF
--- a/reference/clinic.v1.yaml
+++ b/reference/clinic.v1.yaml
@@ -255,16 +255,16 @@ paths:
           description: Time Period to display
           required: true
         - name: tags
-          description: Comma-separated list of patient tag IDs
+          description: |
+            Comma-separated list of patient tag IDs. If provided, only patients tagged with all of the given tags are included in the report. An empty value is ignored, as if the parameter were omitted, and patients are included regardless of their tags.
+          allowEmptyValue: true
           schema:
             type: array
             items:
               $ref: ./common/parameters/objectId.v1.yaml
-            minItems: 1
           in: query
           style: form
           explode: false
-          required: true
         - name: lastDataCutoff
           description: Inclusive minimum of date of last data from a patient.
           schema:

--- a/reference/clinic/models/patientTagIds.v1.yaml
+++ b/reference/clinic/models/patientTagIds.v1.yaml
@@ -2,6 +2,8 @@ type: array
 title: Patient Tag ID List
 uniqueItems: true
 nullable: true
+x-omitzero: true
+x-omitempty: true
 items:
   title: Patient Tag ID
   description: >-

--- a/reference/clinic/models/tide/tideConfig.v1.yaml
+++ b/reference/clinic/models/tide/tideConfig.v1.yaml
@@ -37,6 +37,8 @@ properties:
     x-go-type: float64
   tags:
     $ref: ../patientTagIds.v1.yaml
+  sites:
+    $ref: ../siteIds.v1.yaml
   filters:
     $ref: ./tideFilters.v1.yaml
 
@@ -49,5 +51,4 @@ required:
   - veryHighGlucoseThreshold
   - lowGlucoseThreshold
   - veryLowGlucoseThreshold
-  - tags
   - filters


### PR DESCRIPTION
We're also making sites behave more like tags in the API, since the two concepts are fundamentally similar, it makes sense to have them work similarly in the API.

BACK-4524