### PR TITLE
bump oapi-codegen to v2.8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ $(BUILD_FOLDER) $(CODEGEN_FOLDER) $(TOOLS_BIN):
 
 GO_TOOLS = $(TOOLS_BIN)/oapi-codegen
 
-OAPI_CODEGEN_VERSION = v2.5.0
+OAPI_CODEGEN_VERSION = v2.8.0
 
 $(TOOLS_BIN)/oapi-codegen: $(TOOLS_BIN)/.oapi-codegen.$(OAPI_CODEGEN_VERSION)
 	@GOBIN=$(CURDIR)/$(TOOLS_BIN) go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@$(OAPI_CODEGEN_VERSION)

--- a/reference/xealth.v2.yaml
+++ b/reference/xealth.v2.yaml
@@ -5972,7 +5972,7 @@ components:
                     description: Procedure coding method (PR1-2)
                     example: C4
                   procedureCode:
-                    type: string
+                    type: object
                     description: Procedure code (PR1-3)
                     properties:
                       identifier:
@@ -6007,7 +6007,7 @@ components:
                     description: Procedure date/time (PR1-5)
                     example: '2021-07-29T19:06:49Z'
                   associatedDiagnosisCode:
-                    type: string
+                    type: object
                     description: Associated diagnosis code (PR1-15)
                     properties:
                       identifier:
@@ -11512,7 +11512,7 @@ components:
                     description: Procedure coding method (PR1-2)
                     example: C4
                   procedureCode:
-                    type: string
+                    type: object
                     description: Procedure code (PR1-3)
                     properties:
                       identifier:
@@ -11547,7 +11547,7 @@ components:
                     description: Procedure date/time (PR1-5)
                     example: '2021-07-29T19:06:49Z'
                   associatedDiagnosisCode:
-                    type: string
+                    type: object
                     description: Associated diagnosis code (PR1-15)
                     properties:
                       identifier:
@@ -16998,7 +16998,7 @@ components:
                         description: Procedure coding method (PR1-2)
                         example: C4
                       procedureCode:
-                        type: string
+                        type: object
                         description: Procedure code (PR1-3)
                         properties:
                           identifier:
@@ -17033,7 +17033,7 @@ components:
                         description: Procedure date/time (PR1-5)
                         example: '2021-07-29T19:06:49Z'
                       associatedDiagnosisCode:
-                        type: string
+                        type: object
                         description: Associated diagnosis code (PR1-15)
                         properties:
                           identifier:


### PR DESCRIPTION
This version brings us openapi-3.1 support, should we want it.

The xealth changes are the result of the upgrade. They were improperly
specified. Previous versions of oapi-codegen allowed this, but the
latest versions do not.

BACK-4557