### PR TITLE
Revert "add ability to filter TIDE reports by clinic sites"

### DIFF
--- a/reference/clinic.v1.yaml
+++ b/reference/clinic.v1.yaml
@@ -310,19 +310,6 @@ paths:
             x-go-type-skip-optional-pointer: true
             x-omitempty: true
           in: query
-        - name: sites
-          description: |
-            Comma-separated list of clinic site IDs. If provided, only patients assigned to at least one of the given sites are included in the report. An empty value is ignored, as if the parameter were omitted.
-          allowEmptyValue: true
-          schema:
-            type: array
-            x-omitempty: true
-            x-omitzero: true
-            items:
-              $ref: ./common/parameters/objectId.v1.yaml
-          in: query
-          style: form
-          explode: false
   '/v1/clinics/{clinicId}/patients':
     parameters:
       - $ref: '#/components/parameters/clinicId'
@@ -955,21 +942,21 @@ paths:
         - schema:
             type: array
             items:
-              $ref: ./common/parameters/objectIdOrZero.v1.yaml
+              type: string
+              format: '^[a-f0-9]{24}$'
           in: query
           name: tags
-          description: |
-            Comma-separated list of patient tag IDs. The single value `_` filters for patients without any tags assigned; combining `_` with tag IDs is rejected.
+          description: Comma-separated list of patient tag IDs
           style: form
           explode: false
         - name: sites
           schema:
             type: array
             items:
-              $ref: ./common/parameters/objectIdOrZero.v1.yaml
+              type: string
+              format: '^[a-f0-9]{24}$'
           in: query
-          description: |
-            Comma-separated list of clinic site IDs. The single value `_` filters for patients without any sites assigned; combining `_` with site IDs is rejected.
+          description: Comma-separated list of clinic site IDs
           style: form
           explode: false
         - name: omitNonStandardRanges

--- a/reference/clinic/models/siteIds.v1.yaml
+++ b/reference/clinic/models/siteIds.v1.yaml
@@ -2,7 +2,5 @@ type: array
 title: Site ID List
 uniqueItems: true
 nullable: true
-x-omitzero: true
-x-omitempty: true
 items:
   $ref: ./siteId.v1.yaml

--- a/reference/clinic/models/tide/tideConfig.v1.yaml
+++ b/reference/clinic/models/tide/tideConfig.v1.yaml
@@ -37,8 +37,6 @@ properties:
     x-go-type: float64
   tags:
     $ref: ../patientTagIds.v1.yaml
-  sites:
-    $ref: ../siteIds.v1.yaml
   filters:
     $ref: ./tideFilters.v1.yaml
 

--- a/reference/common/parameters/objectIdOrZero.v1.yaml
+++ b/reference/common/parameters/objectIdOrZero.v1.yaml
@@ -1,6 +1,0 @@
-title: Object Id or Zero Sentinel
-type: string
-description: A resource id, or the underscore sentinel `_` meaning "records with none assigned".
-minLength: 1
-maxLength: 24
-pattern: '^([a-f0-9]{24}|_)$'


### PR DESCRIPTION
This reverts commit a75c85063943e4a928fb1b78ea3aa8eb6a62012a.

This commit was merged prematurely. While it has no impact on
operations, we don't want it gunking up other clinic PRs that will
generate code based on it.

BACK-4559
